### PR TITLE
Fix issue #8 (missing install targets)

### DIFF
--- a/industrial_deprecated/CMakeLists.txt
+++ b/industrial_deprecated/CMakeLists.txt
@@ -62,3 +62,7 @@ catkin_package(
 install(PROGRAMS scripts/fake_time.py
          DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION}
 )
+
+install(DIRECTORY launch/
+         DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION}/launch
+)

--- a/industrial_robot_client/CMakeLists.txt
+++ b/industrial_robot_client/CMakeLists.txt
@@ -137,4 +137,29 @@ catkin_add_gtest(utest_robot_client test/utest.cpp)
 target_link_libraries(utest_robot_client industrial_robot_client ${catkin_LIBRARIES})
 
 
+#############
+## Install ##
+#############
+install(
+    TARGETS industrial_robot_client industrial_robot_client_bswap
+    LIBRARY DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION})
+
+install(TARGETS 
+        robot_state 
+        robot_state_bswap 
+        motion_streaming_interface 
+        motion_download_interface 
+        motion_streaming_interface_bswap 
+        motion_download_interface_bswap 
+        joint_trajectory_action 
+    RUNTIME DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION})
+
+install(
+    DIRECTORY include/${PROJECT_NAME}/
+    DESTINATION ${CATKIN_PACKAGE_INCLUDE_DESTINATION})
+
+foreach(dir config launch)
+   install(DIRECTORY ${dir}/
+      DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION}/${dir})
+endforeach(dir)
 

--- a/industrial_utils/CMakeLists.txt
+++ b/industrial_utils/CMakeLists.txt
@@ -61,4 +61,13 @@ target_link_libraries(${PROJECT_NAME} ${catkin_LIBRARIES})
 catkin_add_gtest(utest_inds_utils test/utest.cpp)
 target_link_libraries(utest_inds_utils ${PROJECT_NAME} ${catkin_LIBRARIES})
 
+#############
+## Install ##
+#############
+install(
+    TARGETS ${PROJECT_NAME} 
+    LIBRARY DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION})
 
+install(
+    DIRECTORY include/${PROJECT_NAME}/
+    DESTINATION ${CATKIN_PACKAGE_INCLUDE_DESTINATION})

--- a/simple_message/CMakeLists.txt
+++ b/simple_message/CMakeLists.txt
@@ -108,3 +108,15 @@ add_dependencies(simple_message_float64 ${industrial_msgs_EXPORTED_TARGETS})
 catkin_add_gtest(utest_float64 ${UTEST_SRC_FILES})
 set_target_properties(utest_float64 PROPERTIES COMPILE_DEFINITIONS "FLOAT64")
 target_link_libraries(utest_float64 simple_message_float64)
+
+
+#############
+## Install ##
+#############
+install(
+    TARGETS simple_message simple_message_bswap simple_message_float64 
+    LIBRARY DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION})
+
+install(
+    DIRECTORY include/${PROJECT_NAME}/
+    DESTINATION ${CATKIN_PACKAGE_INCLUDE_DESTINATION})


### PR DESCRIPTION
Partial fix for the issue: I haven't added any install target(s) to the `industrial_msgs` package yet. Not sure if it needs them, as the generated headers for the messages and services do show up in the install space.
