### PR TITLE
Fix issue #29: Log messages that display errno should display the associated error text instead.

### DIFF
--- a/simple_message/include/simple_message/socket/simple_socket.h
+++ b/simple_message/include/simple_message/socket/simple_socket.h
@@ -203,7 +203,8 @@ protected:
 
   void logSocketError(const char* msg, int rc)
   {
-    LOG_ERROR("%s, rc: %d, errno: %d", msg, rc, errno);
+    int errno_ = errno;
+    LOG_ERROR("%s, rc: %d. Error: '%s' (errno: %d)", msg, rc, strerror(errno_), errno_);
   }
   
   /**


### PR DESCRIPTION
Add error message to socket errors (instead of just errno).

Changes `socketError(..)` output from:

> Failed to connect to server, rc: -1, errno: 113

to:

> Failed to connect to server, rc: -1. Error: 'No route to host' (errno: 113)

which should give some more information to the user.

Fix #29.
