### PR TITLE
Joint feedback handler

### DIFF
--- a/industrial_robot_client/CMakeLists.txt
+++ b/industrial_robot_client/CMakeLists.txt
@@ -13,7 +13,8 @@ add_definitions(-DROS=1)  #build using ROS libraries
 add_definitions(-DLINUXSOCKETS=1)  #build using LINUX SOCKETS libraries
 
 set(SRC_FILES src/joint_relay_handler.cpp
-	      src/robot_status_relay_handler.cpp
+              src/joint_feedback_handler.cpp
+              src/robot_status_relay_handler.cpp
               src/joint_trajectory_downloader.cpp
               src/joint_trajectory_streamer.cpp
               src/joint_trajectory_interface.cpp
@@ -85,6 +86,7 @@ include_directories(include
 
 add_library(industrial_robot_client ${SRC_FILES})
 target_link_libraries(industrial_robot_client simple_message)
+target_link_libraries(industrial_robot_client industrial_utils)
 
 add_library(industrial_robot_client_bswap ${SRC_FILES})
 target_link_libraries(industrial_robot_client_bswap simple_message_bswap)

--- a/industrial_robot_client/include/industrial_robot_client/joint_feedback_handler.h
+++ b/industrial_robot_client/include/industrial_robot_client/joint_feedback_handler.h
@@ -1,0 +1,144 @@
+/*
+* Software License Agreement (BSD License) 
+*
+* Copyright (c) 2011, Southwest Research Institute
+* All rights reserved.
+*
+* Redistribution and use in source and binary forms, with or without
+* modification, are permitted provided that the following conditions are met:
+*
+*   * Redistributions of source code must retain the above copyright
+*   notice, this list of conditions and the following disclaimer.
+*   * Redistributions in binary form must reproduce the above copyright
+*   notice, this list of conditions and the following disclaimer in the
+*   documentation and/or other materials provided with the distribution.
+*   * Neither the name of the Southwest Research Institute, nor the names 
+*   of its contributors may be used to endorse or promote products derived
+*   from this software without specific prior written permission.
+*
+* THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+* AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+* IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+* ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+* LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+* CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+* SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+* INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+* CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+* ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+* POSSIBILITY OF SUCH DAMAGE.
+*/
+
+#ifndef JOINT_FEEDBACK_HANDLER_H
+#define JOINT_HANDLER_H
+
+#include <string>
+#include <vector>
+#include <map>
+
+#include "ros/ros.h"
+#include "control_msgs/FollowJointTrajectoryFeedback.h"
+#include "sensor_msgs/JointState.h"
+#include "simple_message/joint_data.h"
+#include "simple_message/message_handler.h"
+#include "simple_message/simple_message.h"
+#include "simple_message/messages/joint_feedback_message.h"
+
+namespace industrial_robot_client
+{
+namespace joint_feedback_handler
+{
+
+using industrial::joint_data::JointData;
+using industrial::joint_feedback_message::JointFeedbackMessage;
+using industrial::simple_message::SimpleMessage;
+using industrial::smpl_msg_connection::SmplMsgConnection;
+
+
+/**
+ * \brief Message Handler that handles joint feedback messages for multiple
+ * control groups.
+ *
+ * THIS CLASS IS NOT THREAD-SAFE
+ *
+ */
+class JointFeedbackHandler : public industrial::message_handler::MessageHandler
+{
+
+    public:
+        /** \brief Empty class constructor. */
+        JointFeedbackHandler() {};
+
+        /**
+         * \brief Initialize joint feedback handler for single control group.
+         *
+         * \param[in] connection
+         * \param[in] joint_manes vector of joint names
+         *
+         */
+        bool init(industrial::smpl_msg_connection::SmplMsgConnection* connection, std::vector<std::string> &joint_names);
+
+        /**
+         * \brief Initialize joint feedback handler for multiple cotrol groups.
+         *
+         * \param[in] connection
+         * \param[in] joint_manes_map map of joint names vectors by robot id
+         *
+         */
+        bool init(industrial::smpl_msg_connection::SmplMsgConnection* connection, std::map<int, std::vector<std::string> > &joint_names_map);
+
+    protected:
+
+        /** \brief ROS Node handle */
+        ros::NodeHandle node_;
+
+        /** \brief Map of joint names by the robot id */
+        std::map<int, std::vector<std::string> > joint_names_map_;
+
+        ros::Publisher pub_joint_control_state_;
+        ros::Publisher pub_joint_sensor_state_;
+
+        /**
+         * \brief Convert ROS-I JointMessage to std ROS messages.
+         *
+         * \param[in] msg_in
+         * \param[out] control_state
+         * \param[out] sensor_state
+         *
+         * \return true if ok, false in case of error
+         */
+        virtual bool create_messages(JointFeedbackMessage& msg_in,
+                                     control_msgs::FollowJointTrajectoryFeedback* control_state,
+                                     sensor_msgs::JointState* sensor_state);
+
+
+        /**
+         * \brief Get joint names for particular control group.
+         *
+         * \param[in]  robot_id
+         * \param[out] joint_names
+         *
+         * \return true if ok, false in case of error
+         */
+        virtual bool get_joint_names(int robot_id, std::vector<std::string>* joint_names);
+
+        /**
+         * \brief internal callback
+         */
+        bool internalCB(JointFeedbackMessage& in);
+
+    private:
+
+        /**
+         * \brief Internal callback called by MessageManager, it performs
+         * conversion to the JointFeedbackMessage.
+         */
+        bool internalCB(SimpleMessage& in);
+
+};
+
+}
+}
+
+
+#endif

--- a/industrial_robot_client/src/joint_feedback_handler.cpp
+++ b/industrial_robot_client/src/joint_feedback_handler.cpp
@@ -1,0 +1,187 @@
+/*
+* Software License Agreement (BSD License) 
+*
+* Copyright (c) 2011, Southwest Research Institute
+* All rights reserved.
+*
+* Redistribution and use in source and binary forms, with or without
+* modification, are permitted provided that the following conditions are met:
+*
+*   * Redistributions of source code must retain the above copyright
+*   notice, this list of conditions and the following disclaimer.
+*   * Redistributions in binary form must reproduce the above copyright
+*   notice, this list of conditions and the following disclaimer in the
+*   documentation and/or other materials provided with the distribution.
+*   * Neither the name of the Southwest Research Institute, nor the names 
+*   of its contributors may be used to endorse or promote products derived
+*   from this software without specific prior written permission.
+*
+* THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+* AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+* IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+* ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+* LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+* CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+* SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+* INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+* CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+* ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+* POSSIBILITY OF SUCH DAMAGE.
+*/
+
+#include "industrial_robot_client/joint_feedback_handler.h"
+#include "simple_message/log_wrapper.h"
+#include "industrial_utils/utils.h"
+
+using industrial::joint_data::JointData;
+using namespace industrial::simple_message;
+using namespace industrial_utils;
+
+namespace industrial_robot_client
+{
+namespace joint_feedback_handler
+{
+bool JointFeedbackHandler::init(industrial::smpl_msg_connection::SmplMsgConnection* connection, std::vector<std::string> &joint_names)
+{
+    std::map<int, std::vector<std::string> > joint_names_map;
+    joint_names_map[0] = joint_names;
+    return init(connection, joint_names_map);
+}
+
+bool JointFeedbackHandler::init(industrial::smpl_msg_connection::SmplMsgConnection* connection, std::map<int, std::vector<std::string> > &joint_names_map)
+{
+    // Register publishers
+    this->pub_joint_control_state_ = this->node_.advertise<control_msgs::FollowJointTrajectoryFeedback>("feedback_states", 1);
+    this->pub_joint_sensor_state_ = this->node_.advertise<sensor_msgs::JointState>("joint_states", 1);
+
+    // Store joint names
+    this->joint_names_map_ = joint_names_map;
+
+    // Initialize message handler
+    return MessageHandler::init((int)StandardMsgTypes::JOINT_FEEDBACK, connection);
+}
+
+bool JointFeedbackHandler::create_messages(JointFeedbackMessage& msg_in,
+                                           control_msgs::FollowJointTrajectoryFeedback* control_state,
+                                           sensor_msgs::JointState* sensor_state)
+{
+
+    std::vector<std::string> joint_names;
+    get_joint_names(msg_in.getRobotID(), &joint_names);
+    JointData values;
+    int num_jnts = joint_names.size();
+
+    *control_state = control_msgs::FollowJointTrajectoryFeedback();  // always start with a "clean" message
+    control_state->header.stamp = ros::Time::now();
+    control_state->joint_names = joint_names;
+
+    // copy position data
+    if (msg_in.getPositions(values))
+    {
+        if (!jointData2Vector(values, num_jnts, control_state->actual.positions))
+        {
+            LOG_ERROR("Failed to parse position data from JointFeedbackMessage");
+            return false;
+        }
+    } else {
+        control_state->actual.positions.clear();
+    }
+
+    // copy velocity data
+    if (msg_in.getVelocities(values))
+    {
+        if (!jointData2Vector(values, num_jnts, control_state->actual.velocities))
+        {
+            LOG_ERROR("Failed to parse velocity data from JointFeedbackMessage");
+            return false;
+        }
+    } else {
+        control_state->actual.velocities.clear();
+    }
+
+    // copy acceleration data
+    if (msg_in.getAccelerations(values))
+    {
+        if (!jointData2Vector(values, num_jnts, control_state->actual.accelerations))
+        {
+            LOG_ERROR("Failed to parse acceleration data from JointFeedbackMessage");
+            return false;
+        }
+    } else {
+        control_state->actual.accelerations.clear();
+    }
+
+    control_state->actual.time_from_start = ros::Duration(0);
+
+    *sensor_state = sensor_msgs::JointState();  // always start with a "clean" message
+    sensor_state->header.stamp = ros::Time::now();
+    sensor_state->name = joint_names;
+    sensor_state->position = control_state->actual.positions;
+    sensor_state->velocity = control_state->actual.velocities;
+
+    return true;
+}
+bool JointFeedbackHandler::get_joint_names(int robot_id, std::vector<std::string>* joint_names)
+{
+    bool ret = true;
+    joint_names->clear();
+
+    if (this->joint_names_map_.count(robot_id) > 0) {
+        std::vector<std::string> tmp;
+        tmp = this->joint_names_map_[robot_id];
+        for (std::vector<std::string>::iterator it = tmp.begin(); it != tmp.end(); ++it)
+                joint_names->push_back(*it);
+    } else {
+        ROS_ERROR("Undefined control group: %d", robot_id);
+        ret = false;
+    }
+
+    if (joint_names->size() <= 0) {
+        ROS_ERROR("Empty joint names");
+        ret = false;
+    }
+
+    return ret;
+}
+
+bool JointFeedbackHandler::internalCB(JointFeedbackMessage& in)
+{
+
+  control_msgs::FollowJointTrajectoryFeedback control_state;
+  sensor_msgs::JointState sensor_state;
+  bool rtn = true;
+
+  if (create_messages(in, &control_state, &sensor_state))
+  {
+    this->pub_joint_control_state_.publish(control_state);
+    this->pub_joint_sensor_state_.publish(sensor_state);
+  } else {
+    rtn = false;
+  }
+
+  // Reply back to the controller if the sender requested it.
+  if (CommTypes::SERVICE_REQUEST == in.getMessageType())
+  {
+    SimpleMessage reply;
+    reply.init(in.getMessageType(), CommTypes::SERVICE_REPLY, rtn ? ReplyTypes::SUCCESS : ReplyTypes::FAILURE);
+    this->getConnection()->sendMsg(reply);
+  }
+
+  return rtn;
+}
+
+
+bool JointFeedbackHandler::internalCB(SimpleMessage& in)
+{
+    JointFeedbackMessage tmp_msg;
+
+    if (!tmp_msg.init(in)) {
+        return false;
+    }
+
+    return internalCB(tmp_msg);
+}
+
+
+} // end joint_feedback_relay_handler
+} // end industrial_robot_client

--- a/industrial_utils/CMakeLists.txt
+++ b/industrial_utils/CMakeLists.txt
@@ -2,7 +2,7 @@
 cmake_minimum_required(VERSION 2.8.3)
 project(industrial_utils)
 # Load catkin and all dependencies required for this package
-find_package(catkin REQUIRED COMPONENTS roscpp urdf)
+find_package(catkin REQUIRED COMPONENTS roscpp urdf simple_message)
 
 ## System dependencies are found with CMake's conventions
 # find_package(Boost REQUIRED COMPONENTS system)
@@ -56,7 +56,7 @@ include_directories(include
   ${catkin_INCLUDE_DIRS})
 
 add_library(${PROJECT_NAME} src/utils.cpp src/param_utils.cpp)
-target_link_libraries(${PROJECT_NAME} ${catkin_LIBRARIES})
+target_link_libraries(${PROJECT_NAME} ${catkin_LIBRARIES} simple_message)
 
 catkin_add_gtest(utest_inds_utils test/utest.cpp)
 target_link_libraries(utest_inds_utils ${PROJECT_NAME} ${catkin_LIBRARIES})

--- a/industrial_utils/include/industrial_utils/utils.h
+++ b/industrial_utils/include/industrial_utils/utils.h
@@ -36,6 +36,7 @@
 #include <string>
 #include "urdf/model.h"
 #include "sensor_msgs/JointState.h"
+#include "simple_message/joint_data.h"
 
 namespace industrial_utils
 {
@@ -78,6 +79,19 @@ bool isSame(const std::vector<std::string> & lhs, const std::vector<std::string>
  */
 bool findChainJointNames(const boost::shared_ptr<const urdf::Link> &link, bool ignore_fixed,
 		                 std::vector<std::string> &joint_names);
+
+/**
+ *
+ * \brief Helper funcition to convert JointData to vector of doubles.
+ *
+ * \param[in]  joints JointData to be converted
+ * \param[in]  len required length
+ * \param[out] vec JointData in form of a vector
+ *
+ * \return true if sucessful, false in case of error
+ *
+ */
+bool jointData2Vector(const industrial::joint_data::JointData &joints, int len, std::vector<double> &vec);
 
 } //industrial_utils
 

--- a/industrial_utils/src/utils.cpp
+++ b/industrial_utils/src/utils.cpp
@@ -125,4 +125,19 @@ bool findChainJointNames(const boost::shared_ptr<const urdf::Link> &link, bool i
   return true;
 }
 
+bool jointData2Vector(const industrial::joint_data::JointData &joints, int len, std::vector<double> &vec)
+{
+    if ( (len<0) || (len>joints.getMaxNumJoints()) )
+    {
+        ROS_ERROR("Failed to copy JointData.  Len (%d) out of range (0 to %d)", len, joints.getMaxNumJoints());
+        return false;
+    }
+
+    vec.resize(len);
+    for (int i=0; i<len; ++i)
+        vec[i] = joints.getJoint(i);
+
+    return true;
+}
+
 } //industrial_utils


### PR DESCRIPTION
This is an initial implementation of the JointFeedbackHandler. In this state the handler is able to handle JointFeedbackMessage, assign joint names based on the robot id and publish it /joint_state and /joint_feedback message.
