### PR TITLE
Issue #25 fix

### DIFF
--- a/simple_message/CMakeLists.txt
+++ b/simple_message/CMakeLists.txt
@@ -85,6 +85,8 @@ include_directories(include
   ${catkin_INCLUDE_DIRS}
 )
 
+# NOTE: All test files require TEST_PORT_BASE to be defined.  Defining different
+# ports for each test executable allows them to run in parallel.
 
 # DEFAULT LIBRARY (SAME ENDIAN)
 add_library(simple_message ${SRC_FILES})
@@ -92,6 +94,7 @@ target_link_libraries(simple_message ${catkin_LIBRARIES})
 add_dependencies(simple_message ${industrial_msgs_EXPORTED_TARGETS})
 
 catkin_add_gtest(utest ${UTEST_SRC_FILES})
+set_target_properties(utest PROPERTIES COMPILE_DEFINITIONS "TEST_PORT_BASE=11000")
 target_link_libraries(utest simple_message)
 
 # ALTERNATIVE LIBRARY (DIFFERENT ENDIAN)
@@ -101,6 +104,7 @@ target_link_libraries(simple_message_bswap ${catkin_LIBRARIES})
 add_dependencies(simple_message_bswap ${industrial_msgs_EXPORTED_TARGETS})
 
 catkin_add_gtest(utest_byte_swapping ${UTEST_SRC_FILES})
+set_target_properties(utest_byte_swapping PROPERTIES COMPILE_DEFINITIONS "TEST_PORT_BASE=12000")
 target_link_libraries(utest_byte_swapping simple_message_bswap)
 
 # ALTERNATIVE LIBRARY (64-bit floats)
@@ -110,7 +114,7 @@ target_link_libraries(simple_message_float64 ${catkin_LIBRARIES})
 add_dependencies(simple_message_float64 ${industrial_msgs_EXPORTED_TARGETS})
 
 catkin_add_gtest(utest_float64 ${UTEST_SRC_FILES})
-set_target_properties(utest_float64 PROPERTIES COMPILE_DEFINITIONS "FLOAT64")
+set_target_properties(utest_float64 PROPERTIES COMPILE_DEFINITIONS "TEST_PORT_BASE=13000;FLOAT64")
 target_link_libraries(utest_float64 simple_message_float64)
 
 

--- a/simple_message/include/simple_message/socket/simple_socket.h
+++ b/simple_message/include/simple_message/socket/simple_socket.h
@@ -183,9 +183,9 @@ protected:
   static const int MAX_BUFFER_SIZE = 1024;
 
   /**
-   * \brief socket read timeout (ms)
+   * \brief socket ready polling timeout (ms)
    */
-  static const int SOCKET_READ_TO = 1000;
+  static const int SOCKET_POLL_TO = 1000;
 
   /**
    * \brief internal data buffer for receiving

--- a/simple_message/include/simple_message/socket/simple_socket.h
+++ b/simple_message/include/simple_message/socket/simple_socket.h
@@ -181,6 +181,12 @@ protected:
    * in order to avoid dynamic memory allocation)
    */
   static const int MAX_BUFFER_SIZE = 1024;
+
+  /**
+   * \brief socket read timeout (ms)
+   */
+  static const int SOCKET_READ_TO = 1000;
+
   /**
    * \brief internal data buffer for receiving
    */
@@ -207,13 +213,28 @@ protected:
   }
   
   /**
+   * \brief polls socket for data or error
+   *
+   * \param timeout (ms) negative or zero values result in blocking
+   * \param ready true if ready
+   * \param except true if exception
+   *
+   * \return true if function DID NOT timeout (must check flags)
+   */
+  bool poll(int timeout, bool & ready, bool & error);
+
+  /**
    * \brief returns true if socket data is ready to receive
    *
    * \param timeout (ms) negative or zero values result in blocking
    *
    * \return true if data is ready to recieve
    */
-  bool isReadyReceive(int timeout);
+  bool isReadyReceive(int timeout)
+  {
+    bool r, e;
+    return poll(timeout, r, e);
+  }
   
   // Send/Receive functions (inherited classes should override raw methods
   // Virtual

--- a/simple_message/src/socket/simple_socket.cpp
+++ b/simple_message/src/socket/simple_socket.cpp
@@ -121,24 +121,26 @@ namespace industrial
           {
             if(ready)
             {
-              rc = rawReceiveBytes(this->buffer_, num_bytes);
+              rc = rawReceiveBytes(this->buffer_, remainBytes);
               if (this->SOCKET_FAIL == rc)
               {
                 this->logSocketError("Socket received failed", rc);
+		        remainBytes = 0;
                 rtn = false;
                 break;
               }
               else if (0 == rc)
               {
                 LOG_WARN("Recieved zero bytes: %u", rc);
+		        remainBytes = 0;
                 rtn = false;
                 break;
               }
               else
               {
-                remainBytes = num_bytes - rc;
-                LOG_COMM("Byte array receive, bytes read: %u, bytes left: %u",
-                    rc, remainBytes);
+                remainBytes = remainBytes - rc;
+                LOG_COMM("Byte array receive, bytes read: %u, bytes reqd: %u, bytes left: %u",
+                    rc, num_bytes, remainBytes);
                 buffer.load(&this->buffer_, rc);
                 rtn = true;
               }

--- a/simple_message/src/socket/simple_socket.cpp
+++ b/simple_message/src/socket/simple_socket.cpp
@@ -117,7 +117,10 @@ namespace industrial
         buffer.init();
         while (remainBytes > 0)
         {
-          if (this->poll(this->SOCKET_READ_TO, ready, error))
+          // Polling the socket results in an "interruptable" socket read.  This
+          // allows Control-C to break out of a socket read.  Without polling,
+          // a sig-term is required to kill a program in a socket read function.
+          if (this->poll(this->SOCKET_POLL_TO, ready, error))
           {
             if(ready)
             {
@@ -160,7 +163,7 @@ namespace industrial
           }
           else
           {
-            LOG_WARN("Socket poll timeout, trying again");
+            LOG_COMM("Socket poll timeout, trying again");
           }
         }
       }

--- a/simple_message/src/socket/simple_socket.cpp
+++ b/simple_message/src/socket/simple_socket.cpp
@@ -42,155 +42,195 @@ using namespace industrial::shared_types;
 
 namespace industrial
 {
-namespace simple_socket
-{
-
-
-bool SimpleSocket::sendBytes(ByteArray & buffer)
-{
-  int rc = this->SOCKET_FAIL;
-  bool rtn = false;
-
-  if (this->isConnected())
+  namespace simple_socket
   {
-    // Nothing restricts the ByteArray from being larger than the what the socket
-    // can handle.
-    if (this->MAX_BUFFER_SIZE > (int)buffer.getBufferSize())
+
+    bool SimpleSocket::sendBytes(ByteArray & buffer)
     {
-    
-      rc = rawSendBytes(buffer.getRawDataPtr(), buffer.getBufferSize());
+      int rc = this->SOCKET_FAIL;
+      bool rtn = false;
+
+      if (this->isConnected())
+      {
+        // Nothing restricts the ByteArray from being larger than the what the socket
+        // can handle.
+        if (this->MAX_BUFFER_SIZE > (int)buffer.getBufferSize())
+        {
+
+          rc = rawSendBytes(buffer.getRawDataPtr(), buffer.getBufferSize());
+          if (this->SOCKET_FAIL != rc)
+          {
+            rtn = true;
+          }
+          else
+          {
+            rtn = false;
+            logSocketError("Socket sendBytes failed", rc);
+          }
+
+        }
+        else
+        {
+          LOG_ERROR("Buffer size: %u, is greater than max socket size: %u", buffer.getBufferSize(), this->MAX_BUFFER_SIZE);
+          rtn = false;
+        }
+
+      }
+      else
+      {
+        rtn = false;
+        LOG_WARN("Not connected, bytes not sent");
+      }
+
+      if (!rtn)
+      {
+        this->setConnected(false);
+      }
+
+      return rtn;
+
+    }
+
+    bool SimpleSocket::receiveBytes(ByteArray & buffer, shared_int num_bytes)
+    {
+      int rc = this->SOCKET_FAIL;
+      bool rtn = false;
+      shared_int remainBytes = num_bytes;
+      bool ready, error;
+
+      // Reset the buffer (this is not required since the buffer length should
+      // ensure that we don't read any of the garbage that may be left over from
+      // a previous read), but it is good practice.
+
+      memset(&this->buffer_, 0, sizeof(this->buffer_));
+
+      // Doing a sanity check to determine if the byte array buffer is larger than
+      // what can be sent in the socket.  This should not happen and might be indicative
+      // of some code synchronization issues between the client and server base.
+      if (this->MAX_BUFFER_SIZE < (int)buffer.getMaxBufferSize())
+      {
+        LOG_WARN("Socket buffer max size: %u, is larger than byte array buffer: %u",
+            this->MAX_BUFFER_SIZE, buffer.getMaxBufferSize());
+      }
+      if (this->isConnected())
+      {
+        buffer.init();
+        while (remainBytes > 0)
+        {
+          if (this->poll(this->SOCKET_READ_TO, ready, error))
+          {
+            if(ready)
+            {
+              rc = rawReceiveBytes(this->buffer_, num_bytes);
+              if (this->SOCKET_FAIL == rc)
+              {
+                this->logSocketError("Socket received failed", rc);
+                rtn = false;
+                break;
+              }
+              else if (0 == rc)
+              {
+                LOG_WARN("Recieved zero bytes: %u", rc);
+                rtn = false;
+                break;
+              }
+              else
+              {
+                remainBytes = num_bytes - rc;
+                LOG_COMM("Byte array receive, bytes read: %u, bytes left: %u",
+                    rc, remainBytes);
+                buffer.load(&this->buffer_, rc);
+                rtn = true;
+              }
+            }
+            else if(error)
+            {
+              LOG_ERROR("Socket poll returned an error");
+              rtn = false;
+              break;
+            }
+            else
+            {
+              LOG_ERROR("Uknown error from socket poll");
+              rtn = false;
+              break;
+            }
+          }
+          else
+          {
+            LOG_WARN("Socket poll timeout, trying again");
+          }
+        }
+      }
+      else
+      {
+        LOG_WARN("Not connected, bytes not sent");
+        rtn = false;
+      }
+
+      if (!rtn)
+      {
+        this->setConnected(false);
+      }
+      return rtn;
+    }
+
+    bool SimpleSocket::poll(int timeout, bool & ready, bool & error)
+    {
+      timeval time;
+      fd_set read, write, except;
+      int rc = this->SOCKET_FAIL;
+      bool rtn = false;
+      ready = false;
+      error = false;
+
+      // The select function uses the timeval data structure
+      time.tv_sec = timeout / 1000;
+      time.tv_usec = (timeout % 1000) * 1000;
+
+      FD_ZERO(&read);
+      FD_ZERO(&write);
+      FD_ZERO(&except);
+
+      FD_SET(this->getSockHandle(), &read);
+      FD_SET(this->getSockHandle(), &except);
+
+      rc = SELECT(this->getSockHandle() + 1, &read, &write, &except, &time);
+
       if (this->SOCKET_FAIL != rc)
       {
-        rtn = true;
+        if (0 == rc)
+        {
+          rtn = false;
+        }
+        else
+        {
+          if (FD_ISSET(this->getSockHandle(), &read))
+          {
+            ready = true;
+            rtn = true;
+          }
+          else if(FD_ISSET(this->getSockHandle(), &except))
+          {
+            error = true;
+            rtn = true;
+          }
+          else
+          {
+            LOG_WARN("Select returned, but no flags are set");
+            rtn = false;
+          }
+        }
       }
       else
       {
-        rtn = false;
-        logSocketError("Socket sendBytes failed", rc);
-      }
-      
-      }
-    else
-    {
-      LOG_ERROR("Buffer size: %u, is greater than max socket size: %u", buffer.getBufferSize(), this->MAX_BUFFER_SIZE);
-      rtn = false;
-    }
-
-  }
-  else
-  {
-    rtn = false;
-    LOG_WARN("Not connected, bytes not sent");
-  }
-
-  if (!rtn)
-    {
-      this->setConnected(false);
-    }
-
-  return rtn;
-  
-}
-
-bool SimpleSocket::receiveBytes(ByteArray & buffer, shared_int num_bytes)
-{
-  int rc = this->SOCKET_FAIL;
-  bool rtn = false;
-  
-  // Reset the buffer (this is not required since the buffer length should
-  // ensure that we don't read any of the garbage that may be left over from
-  // a previous read), but it is good practice.
-
-  memset(&this->buffer_, 0, sizeof(this->buffer_));
-
-  // Doing a sanity check to determine if the byte array buffer is larger than
-  // what can be sent in the socket.  This should not happen and might be indicative
-  // of some code synchronization issues between the client and server base.
-  if (this->MAX_BUFFER_SIZE < (int)buffer.getMaxBufferSize())
-  {
-    LOG_WARN("Socket buffer max size: %u, is larger than byte array buffer: %u",
-             this->MAX_BUFFER_SIZE, buffer.getMaxBufferSize());
-  }
-  if (this->isConnected())
-  {
-    rc = rawReceiveBytes(this->buffer_, num_bytes);
-
-    if (this->SOCKET_FAIL != rc)
-    {
-      if (rc > 0)
-      {
-        LOG_COMM("Byte array receive, bytes read: %u", rc);
-        buffer.init(&this->buffer_[0], rc);
-        rtn = true;
-      }
-      else
-      {
-        LOG_WARN("Recieved zero bytes: %u", rc);
+        this->logSocketError("Socket select function failed", rc);
         rtn = false;
       }
+
+      return rtn;
     }
-    else
-    {
-      this->logSocketError("Socket received failed", rc);
-      rtn = false;
-    }
-  }
-  else
-  {
-    rtn = false;
-    LOG_WARN("Not connected, bytes not sent");
-  }
 
-  if (!rtn)
-  {
-    this->setConnected(false);
-  }
-  return rtn;
-}
-
-bool SimpleSocket::isReadyReceive(int timeout)
-{
-  timeval time;
-  fd_set read, write, except;
-  int rc = this->SOCKET_FAIL;
-  bool rtn = false;
-  
-  // The select function uses the timeval data structure
-  time.tv_sec = timeout/1000;
-  time.tv_usec = (timeout%1000)*1000;
-  
-  FD_ZERO(&read);
-  FD_ZERO(&write);
-  FD_ZERO(&except);
-  
-  FD_SET(this->getSockHandle(), &read);
-  
-  rc = SELECT(this->getSockHandle() + 1, &read, &write, &except, &time);
-  
-  if (this->SOCKET_FAIL != rc)
-  {
-    if (0==rc)
-    {
-      LOG_DEBUG("Socket select timed out");
-      rtn = false;
-    }
-    else
-    {
-      LOG_DEBUG("Data is ready for reading");
-      rtn = true;
-    }
-  }
-  else
-  {
-    this->logSocketError("Socket select function failed", rc);
-    rtn = false;
-  }
-  
-  return rtn;
-}
-
-
-
-} //simple_socket
-} //industrial
+  }  //simple_socket
+}  //industrial
 

--- a/simple_message/test/utest.cpp
+++ b/simple_message/test/utest.cpp
@@ -255,7 +255,7 @@ class TestTcpServer : public TcpServer
     return TcpServer::receiveBytes(buffer, num_bytes);
   }
 };
-TEST(SocketSuite, issue25)
+TEST(SocketSuite, read)
 {
   const int tcpPort = TEST_PORT_BASE;
   char ipAddr[] = "127.0.0.1";
@@ -264,7 +264,8 @@ TEST(SocketSuite, issue25)
   TestTcpServer tcpServer;
   ByteArray send, recv;
   shared_int DATA = 99;
-  shared_int RECV_BYTES = 2 * sizeof(shared_int);
+  shared_int TWO_INTS = 2 * sizeof(shared_int);
+  shared_int ONE_INTS = 1 * sizeof(shared_int);
 
   // Construct server
   ASSERT_TRUE(tcpServer.init(tcpPort));
@@ -277,12 +278,21 @@ TEST(SocketSuite, issue25)
 
   ASSERT_TRUE(send.load(DATA));
 
+  // Send just right amount
   ASSERT_TRUE(tcpClient.sendBytes(send));
+  ASSERT_TRUE(tcpClient.sendBytes(send));
+  ASSERT_TRUE(tcpServer.receiveBytes(recv, TWO_INTS));
+  ASSERT_EQ(TWO_INTS, recv.getBufferSize());
 
-  // Give incorrect byte length to receive bytes
-  ASSERT_TRUE(tcpServer.receiveBytes(recv, RECV_BYTES));
 
-  ASSERT_EQ(RECV_BYTES, recv.getBufferSize());
+  // Send too many bytes
+  ASSERT_TRUE(tcpClient.sendBytes(send));
+  ASSERT_TRUE(tcpClient.sendBytes(send));
+  ASSERT_TRUE(tcpClient.sendBytes(send));
+  ASSERT_TRUE(tcpServer.receiveBytes(recv, TWO_INTS));
+  ASSERT_EQ(TWO_INTS, recv.getBufferSize());
+  ASSERT_TRUE(tcpServer.receiveBytes(recv, ONE_INTS));
+  ASSERT_EQ(ONE_INTS, recv.getBufferSize());
 }
 
 

--- a/simple_message/test/utest.cpp
+++ b/simple_message/test/utest.cpp
@@ -335,6 +335,7 @@ TEST(SocketSuite, splitPackets)
   pthread_create(&senderThrd, NULL, spinSender, &tcpClient);
 
   ASSERT_TRUE(tcpServer.receiveBytes(recv, RECV_LENGTH));
+  ASSERT_EQ(RECV_LENGTH, recv.getBufferSize());
 
   pthread_cancel(senderThrd);
   pthread_join(senderThrd, NULL);


### PR DESCRIPTION
These changes address split packet issues associated with the tcp socket read command (issue #25). 

The read command was changed to utilize the socket select function to query the socket buffer state.  This allows the read to poll the socket for new data in a "interrupt-able" way.  This means that "Control-C" will break out of the program as expected.  The previous approach of simply reading or performing a blocking read did not seem to work this way.

Unit tests were performed that demonstrated the problem and verified the fix.

Minor changes were made to allow parallel test execution (default under catkin).
