### PR TITLE
Fix issue #35: missing install target for launchfile in industrial_robot_simulator

### DIFF
--- a/industrial_robot_simulator/CMakeLists.txt
+++ b/industrial_robot_simulator/CMakeLists.txt
@@ -27,3 +27,5 @@ catkin_package(
 # See http://ros.org/doc/groovy/api/catkin/html/adv_user_guide/variables.html
 
 install(PROGRAMS industrial_robot_simulator DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION})
+
+install(DIRECTORY launch/ DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION}/launch)


### PR DESCRIPTION
`CMakeLists.txt` did not install the launchfile for the simulator, causing errors when trying to use it in an install space.
