### PR TITLE
Fix issue #53: hard coded Python path in robot_simulator script

### DIFF
--- a/industrial_robot_simulator/industrial_robot_simulator
+++ b/industrial_robot_simulator/industrial_robot_simulator
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 
 import roslib; roslib.load_manifest('industrial_robot_simulator')
 import rospy


### PR DESCRIPTION
As per subject. Minor change. Perhaps we should explicitly specify python2 in the shebang.

This is against `groovy-devel`.
