### PR TITLE
Incorporate roslaunch tests.

### DIFF
--- a/industrial_robot_client/CMakeLists.txt
+++ b/industrial_robot_client/CMakeLists.txt
@@ -157,12 +157,23 @@ target_link_libraries(joint_trajectory_action
   industrial_robot_client ${catkin_LIBRARIES})
 add_dependencies(joint_trajectory_action industrial_robot_client_gencpp)
 
+##########
+## Test ##
+##########
 # Testing - Only performed on normal (non byte swapped library)
 catkin_add_gtest(utest_robot_client test/utest.cpp)
 target_link_libraries(utest_robot_client 
   industrial_robot_client 
   ${catkin_LIBRARIES})
 
+# ROS launch testing
+## ROS launch test should be enabled when launch parameters are supported,
+## see details below:
+## robot_interface_streaming.launch: 'robot_ip'
+## robot_state_visualize.launch]: 'urdf_path'
+## robot_interface_download.launch]: 'robot_ip'
+##find_package(roslaunch)
+##roslaunch_add_file_check(launch)
 
 #############
 ## Install ##

--- a/industrial_robot_simulator/CMakeLists.txt
+++ b/industrial_robot_simulator/CMakeLists.txt
@@ -24,8 +24,10 @@ catkin_package(
 ##########
 
 # ROS launch testing
-find_package(roslaunch)
-roslaunch_add_file_check(launch)
+## ROS launch testing should be re-enabled when the roslaunch script is officially
+## released (see https://github.com/ros/ros_comm/pull/333)
+##find_package(roslaunch)
+##roslaunch_add_file_check(launch)
 
 #############
 ## Install ##

--- a/industrial_robot_simulator/CMakeLists.txt
+++ b/industrial_robot_simulator/CMakeLists.txt
@@ -19,6 +19,14 @@ catkin_package(
     CATKIN_DEPENDS roscpp std_msgs sensor_msgs control_msgs trajectory_msgs industrial_robot_client
 )
 
+##########
+## Test ##
+##########
+
+# ROS launch testing
+find_package(roslaunch)
+roslaunch_add_file_check(launch)
+
 #############
 ## Install ##
 #############


### PR DESCRIPTION
Interim pull request for roslaunch dependency checking ( partially addresses ros-industrial/ros_industrial_issues#11 ).  Tests have been commented out, once ros/ros_comm#332 is released into debs, the comments should be removed.  Requesting a pull so this work isn't lost or forgotten.

@gavanderhoorn, please review.
