### PR TITLE
Fix issue #67: update workaround for #46 to include industrial_robot_client

### DIFF
--- a/industrial_robot_client/CMakeLists.txt
+++ b/industrial_robot_client/CMakeLists.txt
@@ -30,6 +30,8 @@ catkin_package(
       simple_message actionlib_msgs actionlib urdf industrial_msgs
       industrial_utils
     INCLUDE_DIRS include
+    LIBRARIES ${PROJECT_NAME}_dummy
+    CFG_EXTRAS issue46_workaround.cmake
 )
 
 
@@ -39,8 +41,17 @@ include_directories(include
 )
 
 
-# do some trickery with the linker for simple_message
-simple_message_linker_setup()
+# generate dummy library (we export it in catkin_package(..)), to force catkin
+# to set up LIBRARY_DIRS properly.
+# TODO: find out if LIBRARY_DIRS can be exported without dummy library target
+add_custom_command(
+  OUTPUT  ${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}_dummy.cpp
+  COMMAND ${CMAKE_COMMAND} -E touch ${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}_dummy.cpp)
+add_library(${PROJECT_NAME}_dummy ${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}_dummy.cpp)
+# unfortunately this will have to be installed, but the linker will remove it
+# from the library dependencies of dependent targets, as it contains no symbols
+# that can be imported from it.
+install(TARGETS ${PROJECT_NAME}_dummy DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION})
 
 
 # This library depends on the simple_message library, which is available

--- a/industrial_robot_client/cmake/issue46_workaround.cmake
+++ b/industrial_robot_client/cmake/issue46_workaround.cmake
@@ -1,0 +1,10 @@
+# 
+# Temporary workaround for issue ros-industrial/industrial_core#46.
+# 
+message(STATUS "industrial_robot_client: work around for #46")
+if (DEFINED industrial_robot_client_LIBRARY_DIRS)
+else()
+    message(FATAL_ERROR "industrial_robot_client_LIBRARY_DIRS not set, "
+        "have you find_package()-ed it?")
+endif()
+link_directories(${industrial_robot_client_LIBRARY_DIRS})

--- a/simple_message/CMakeLists.txt
+++ b/simple_message/CMakeLists.txt
@@ -70,8 +70,8 @@ set(UTEST_SRC_FILES test/utest.cpp test/utest_message.cpp)
 catkin_package(
     CATKIN_DEPENDS roscpp industrial_msgs
     INCLUDE_DIRS include
-    LIBRARIES simple_message_dummy
-    CFG_EXTRAS simple_message_linker_setup.cmake
+    LIBRARIES ${PROJECT_NAME}_dummy
+    CFG_EXTRAS issue46_workaround.cmake
 )
 
 
@@ -81,16 +81,16 @@ include_directories(include
 
 
 # generate dummy library (we export it in catkin_package(..)), to force catkin
-# to set up simple_message_LIBRARY_DIRS properly.
+# to set up LIBRARY_DIRS properly.
 # TODO: find out if LIBRARY_DIRS can be exported without dummy library target
 add_custom_command(
-  OUTPUT  ${CMAKE_CURRENT_BINARY_DIR}/simple_message_dummy.cpp
-  COMMAND ${CMAKE_COMMAND} -E touch ${CMAKE_CURRENT_BINARY_DIR}/simple_message_dummy.cpp)
-add_library(simple_message_dummy ${CMAKE_CURRENT_BINARY_DIR}/simple_message_dummy.cpp)
+  OUTPUT  ${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}_dummy.cpp
+  COMMAND ${CMAKE_COMMAND} -E touch ${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}_dummy.cpp)
+add_library(${PROJECT_NAME}_dummy ${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}_dummy.cpp)
 # unfortunately this will have to be installed, but the linker will remove it
 # from the library dependencies of dependent targets, as it contains no symbols
 # that can be imported from it.
-install(TARGETS simple_message_dummy DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION})
+install(TARGETS ${PROJECT_NAME}_dummy DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION})
 
 
 # NOTE: All test files require TEST_PORT_BASE to be defined.  Defining different

--- a/simple_message/cmake/issue46_workaround.cmake
+++ b/simple_message/cmake/issue46_workaround.cmake
@@ -1,0 +1,10 @@
+# 
+# Temporary workaround for issue ros-industrial/industrial_core#46.
+# 
+message(STATUS "simple_message: work around for #46")
+if (DEFINED simple_message_LIBRARY_DIRS)
+else()
+    message(FATAL_ERROR "simple_message_LIBRARY_DIRS not set, "
+        "have you find_package()-ed it?")
+endif()
+link_directories(${simple_message_LIBRARY_DIRS})

--- a/simple_message/cmake/simple_message_linker_setup.cmake
+++ b/simple_message/cmake/simple_message_linker_setup.cmake
@@ -1,9 +1,0 @@
-
-function(simple_message_linker_setup)
-    if (DEFINED simple_message_LIBRARY_DIRS)
-    else()
-        message(FATAL_ERROR "simple_message_LIBRARY_DIRS not set, "
-            "have you find_package()-ed it?")
-    endif()
-    link_directories(${simple_message_LIBRARY_DIRS})
-endfunction()


### PR DESCRIPTION
Also removes the need to invoke the `X_linker_setup()` function in dependent packages.
