### PR TITLE
Trajectory action should abort on robot error.

### DIFF
--- a/industrial_robot_client/src/joint_trajectory_action.cpp
+++ b/industrial_robot_client/src/joint_trajectory_action.cpp
@@ -73,6 +73,16 @@ JointTrajectoryAction::~JointTrajectoryAction()
 void JointTrajectoryAction::robotStatusCB(const industrial_msgs::RobotStatusConstPtr &msg)
 {
   last_robot_status_ = msg; //caching robot status for later use.
+
+  if(has_active_goal_ && msg->error_code != 0)
+  {
+    std::stringstream ss;
+    ss << "Error code " << msg->error_code << " from joint_trajectory_streamer.";
+    control_msgs::FollowJointTrajectoryResult result;
+    result.error_code = control_msgs::FollowJointTrajectoryResult::INVALID_GOAL;
+    active_goal_.setAborted(result, ss.str());
+    has_active_goal_ = false;
+  }
 }
 
 void JointTrajectoryAction::watchdog(const ros::TimerEvent &e)

--- a/industrial_utils/src/utils.cpp
+++ b/industrial_utils/src/utils.cpp
@@ -78,7 +78,7 @@ bool findChainJointNames(const boost::shared_ptr<const urdf::Link> &link, bool i
 
   // check for joints directly connected to this link
   const joint_list &joints = link->child_joints;
-  ROS_DEBUG("Found %d child joints:", joints.size());
+  ROS_DEBUG("Found %d child joints:", int(joints.size()));
   for (joint_list::const_iterator it=joints.begin(); it!=joints.end(); ++it)
   {
     ROS_DEBUG_STREAM("  " << (*it)->name << ": type " <<  (*it)->type);
@@ -100,7 +100,7 @@ bool findChainJointNames(const boost::shared_ptr<const urdf::Link> &link, bool i
   // check for joints connected to children of this link
   const link_list &links = link->child_links;
   std::vector<std::string> sub_joints;
-  ROS_DEBUG("Found %d child links:", links.size());
+  ROS_DEBUG("Found %d child links:", int(links.size()));
   for (link_list::const_iterator it=links.begin(); it!=links.end(); ++it)
   {
     ROS_DEBUG_STREAM("  " << (*it)->name);


### PR DESCRIPTION
When a robot status message is received with a non-zero error code, any active trajectory goal should be aborted.  Without this, the only way to know that a failure has happened is for the action client to time-out.

Also fixed some compiler warnings about printing unsigned integers with %d format.
