### PR TITLE
Fix for issue #63: remove redundant roslib.load_manifest() from robot_simulator

### DIFF
--- a/industrial_robot_simulator/industrial_robot_simulator
+++ b/industrial_robot_simulator/industrial_robot_simulator
@@ -1,6 +1,5 @@
 #!/usr/bin/env python
 
-import roslib; roslib.load_manifest('industrial_robot_simulator')
 import rospy
 import copy
 import threading


### PR DESCRIPTION
As per subject.

No longer necessary according to [catkin/what#Python Modules (Libraries)](http://wiki.ros.org/catkin/what#Python_Modules_.28Libraries.29).
