### PR TITLE
Issue#114 - Action Server withinGoalConstraints check removal

### DIFF
--- a/industrial_robot_client/src/joint_trajectory_action.cpp
+++ b/industrial_robot_client/src/joint_trajectory_action.cpp
@@ -139,28 +139,16 @@ void JointTrajectoryAction::goalCB(JointTractoryActionServer::GoalHandle & gh)
         ROS_WARN("Received new goal, canceling current goal");
         abortGoal();
       }
+      
+      gh.setAccepted();
+      active_goal_ = gh;
+      has_active_goal_ = true;
 
-      // Sends the trajectory along to the controller
-      if (withinGoalConstraints(last_trajectory_state_, gh.getGoal()->trajectory))
-      {
+      ROS_INFO("Publishing trajectory");
 
-        ROS_INFO_STREAM("Already within goal constraints, setting goal succeeded");
-        gh.setAccepted();
-        gh.setSucceeded();
-        has_active_goal_ = false;
-
-      }
-      else
-      {
-        gh.setAccepted();
-        active_goal_ = gh;
-        has_active_goal_ = true;
-
-        ROS_INFO("Publishing trajectory");
-
-        current_traj_ = active_goal_.getGoal()->trajectory;
-        pub_trajectory_command_.publish(current_traj_);
-      }
+      current_traj_ = active_goal_.getGoal()->trajectory;
+      pub_trajectory_command_.publish(current_traj_);
+    
     }
     else
     {


### PR DESCRIPTION
This PR removes the goal constraints check from the goal-acceptance function of the industrial action server. Because of a previous check to size of the trajectory, this effectively removes only the check on whether the first and last points are the same. 

The robot continues to check for goal completion in the callback, but that should behave correctly. In my own testing, this pull request has fixed the issues I was experiencing.
