### PR TITLE
Switch ByteArray to <deque> for internal buffer

### DIFF
--- a/simple_message/src/simple_message.cpp
+++ b/simple_message/src/simple_message.cpp
@@ -119,7 +119,7 @@ void SimpleMessage::toByteArray(ByteArray & msg)
   msg.load(this->getReplyCode());
   if (this->data_.getBufferSize() > 0 )
   {
-    msg.load(this->getData().getRawDataPtr(), this->data_.getBufferSize());
+    msg.load(this->data_);
   }
 
 }

--- a/simple_message/src/socket/udp_client.cpp
+++ b/simple_message/src/socket/udp_client.cpp
@@ -101,12 +101,18 @@ bool UdpClient::makeConnect()
     this->setConnected(false);
     send.load((void*)&sendHS, sizeof(sendHS));
   
+    // copy to local array, since ByteArray no longer supports
+    // direct pointer-access to data values
+    const int sendLen = send.getBufferSize();
+    char      localBuffer[sendLen];
+    send.unload(localBuffer, sendLen);
+
     do
     {
       ByteArray recv;
       recvHS = 0;
       LOG_DEBUG("UDP client sending handshake");
-      this->rawSendBytes(send.getRawDataPtr(), send.getBufferSize());
+      this->rawSendBytes(localBuffer, sendLen);
       if (this->isReadyReceive(timeout))
       {
         bytesRcvd = this->rawReceiveBytes(this->buffer_, 0);

--- a/simple_message/src/socket/udp_server.cpp
+++ b/simple_message/src/socket/udp_server.cpp
@@ -142,8 +142,14 @@ bool UdpServer::makeConnect()
     }
     while(recvHS != sendHS);
     
+    // copy to local array, since ByteArray no longer supports
+    // direct pointer-access to data values
+    const int sendLen = send.getBufferSize();
+    char      localBuffer[sendLen];
+    send.unload(localBuffer, sendLen);
+
     // Send a reply handshake
-    this->rawSendBytes(send.getRawDataPtr(), send.getBufferSize());
+    this->rawSendBytes(localBuffer, sendLen);
     this->setConnected(true);
     rtn = true;
     


### PR DESCRIPTION
- enables dynamic sizing, for larger messages
  - up to INT_MAX, which is unadvised
- allows efficient data access at front/rear of msgs
- maintains same external API
  - getRawDataPtr() is deprecated (not contiguous memory)
- bugFix: SimpleSocket::receiveBytes() buffer-size check
- update unit tests to handle ByteArray.MaxSize==INT_MAX
