### PR TITLE
Further Trajectory Completion Adjustments

### DIFF
--- a/industrial_robot_client/include/industrial_robot_client/joint_trajectory_action.h
+++ b/industrial_robot_client/include/industrial_robot_client/joint_trajectory_action.h
@@ -155,6 +155,12 @@ private:
   industrial_msgs::RobotStatusConstPtr last_robot_status_;
 
   /**
+   * \brief Time at which to start checking for completion of current 
+   * goal, if one is active
+   */
+  ros::Time time_to_check_;
+
+  /**
    * \brief The watchdog period (seconds)
    */
   static const double WATCHDOG_PERIOD_;// = 1.0;

--- a/industrial_robot_client/src/joint_trajectory_action.cpp
+++ b/industrial_robot_client/src/joint_trajectory_action.cpp
@@ -137,6 +137,8 @@ void JointTrajectoryAction::goalCB(JointTractoryActionServer::GoalHandle & gh)
       gh.setAccepted();
       active_goal_ = gh;
       has_active_goal_ = true;
+      time_to_check_ = ros::Time::now() + 
+          ros::Duration(active_goal_.getGoal()->trajectory.points.back().time_from_start.toSec() / 2.0);
 
       ROS_INFO("Publishing trajectory");
 
@@ -219,6 +221,12 @@ void JointTrajectoryAction::controllerStateCB(const control_msgs::FollowJointTra
   if (!industrial_utils::isSimilar(joint_names_, msg->joint_names))
   {
     ROS_ERROR("Joint names from the controller don't match our joint names.");
+    return;
+  }
+
+  if (ros::Time::now() < time_to_check_)
+  {
+    ROS_DEBUG("Waiting to check for goal completion until halfway through trajectory");
     return;
   }
 


### PR DESCRIPTION
This PR follows up on #115 addressing #114. 

While #115 removes the immediate check for goal completion, the action server can still terminate immediately upon the relieving its first feedback if a point toward the beginning of the trajectory is close to the end and the robot is slow to start.

This PR forces the action server to wait for half of the trajectories total duration before checking for the robot state against the end state. This gives time for the robot to start moving and publishing the `in motion` flag.

I have tested this pretty extensively in the Godel project and it seems to fix my issues. I am not sure if this is an appropriate solution, even as a temporary fix, but the issue remains and I thought I'd at least see what y'all think.
