### PR TITLE
Start checking for trajectory completion as soon as the first moving …

### DIFF
--- a/industrial_robot_client/include/industrial_robot_client/joint_trajectory_action.h
+++ b/industrial_robot_client/include/industrial_robot_client/joint_trajectory_action.h
@@ -114,6 +114,12 @@ private:
   bool has_active_goal_;
 
   /**
+   * \brief Indicates that the robot has been in a moving state at least once since
+   * starting the current active trajectory
+   */
+  bool has_moved_once_;
+
+  /**
    * \brief Cache of the current active goal
    */
   JointTractoryActionServer::GoalHandle active_goal_;


### PR DESCRIPTION
…status arrives

This is a hotfix to #124 as discussed in cbdf113. It addresses cases where the computed duration of a trajectory execution is way longer than the time actually needed by the robot/controller
