### PR TITLE
[CI] Switch from submodule to clone (see https://github.com/ros-industrial/industrial_ci/issues/3 thanks to @ipa-mdl)

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,0 @@
-[submodule ".ci_config"]
-	path = .ci_config
-	url = https://github.com/ros-industrial/industrial_ci.git

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,6 +19,8 @@ matrix:
   allow_failures:
     - env: USE_DEB=true  ROS_DISTRO="jade"   ROS_REPOSITORY_PATH=http://packages.ros.org/ros/ubuntu
     - env: USE_DEB=true  ROS_DISTRO="jade"   ROS_REPOSITORY_PATH=http://packages.ros.org/ros-shadow-fixed/ubuntu
+install:
+  - git clone https://github.com/ros-industrial/industrial_ci.git .ci_config
 script: 
   - source .ci_config/travis.sh
 #  - source ./travis.sh  # Enable this when you have a package-local script 


### PR DESCRIPTION
With this change suggested by @ipa-mdl, maintainers no longer need to take any action when there's change in `industrial_ci` repo. See more in https://github.com/ros-industrial/industrial_ci/issues/3#issuecomment-164016120

Although as pointed out in https://github.com/ros-industrial/industrial_core/pull/126#issuecomment-161856876, the travis build is expected to fail, which should likely be unrelated to this change.
