### PR TITLE
Fix for issue #130: correct typo in SpecialSeqVal enum member name

### DIFF
--- a/simple_message/include/simple_message/joint_traj_pt.h
+++ b/simple_message/include/simple_message/joint_traj_pt.h
@@ -53,7 +53,11 @@ namespace SpecialSeqValues
 {
 enum SpecialSeqValue
 {
-  START_TRAJECTORY_DOWNLOAD = -1, START_TRAJECOTRY_STREAMING = -2, END_TRAJECTORY = -3, STOP_TRAJECTORY = -4
+  START_TRAJECTORY_DOWNLOAD  = -1,
+  START_TRAJECOTRY_STREAMING = -2, ///< deprecated, please use START_TRAJECTORY_STREAMING instead
+  START_TRAJECTORY_STREAMING = -2,
+  END_TRAJECTORY  = -3,
+  STOP_TRAJECTORY = -4
 };
 }
 typedef SpecialSeqValues::SpecialSeqValue SpecialSeqValue;

--- a/simple_message/include/simple_message/joint_traj_pt.h
+++ b/simple_message/include/simple_message/joint_traj_pt.h
@@ -53,11 +53,11 @@ namespace SpecialSeqValues
 {
 enum SpecialSeqValue
 {
-  START_TRAJECTORY_DOWNLOAD  = -1,
+  START_TRAJECTORY_DOWNLOAD  = -1, ///< Downloading drivers only: signal start of trajectory
   START_TRAJECOTRY_STREAMING = -2, ///< deprecated, please use START_TRAJECTORY_STREAMING instead
-  START_TRAJECTORY_STREAMING = -2,
-  END_TRAJECTORY  = -3,
-  STOP_TRAJECTORY = -4
+  START_TRAJECTORY_STREAMING = -2, ///< Streaming drivers only: signal start of trajectory
+  END_TRAJECTORY  = -3, ///< Downloading drivers only: signal end of trajectory
+  STOP_TRAJECTORY = -4  ///< Server should stop the current motion (if any) as soon as possible
 };
 }
 typedef SpecialSeqValues::SpecialSeqValue SpecialSeqValue;

--- a/simple_message/include/simple_message/joint_traj_pt_full.h
+++ b/simple_message/include/simple_message/joint_traj_pt_full.h
@@ -53,7 +53,11 @@ namespace SpecialSeqValues
 {
 enum SpecialSeqValue
 {
-  START_TRAJECTORY_DOWNLOAD = -1, START_TRAJECOTRY_STREAMING = -2, END_TRAJECTORY = -3, STOP_TRAJECTORY = -4
+  START_TRAJECTORY_DOWNLOAD  = -1,
+  START_TRAJECOTRY_STREAMING = -2, ///< deprecated, please use START_TRAJECTORY_STREAMING instead
+  START_TRAJECTORY_STREAMING = -2,
+  END_TRAJECTORY  = -3,
+  STOP_TRAJECTORY = -4
 };
 }
 typedef SpecialSeqValues::SpecialSeqValue SpecialSeqValue;

--- a/simple_message/include/simple_message/joint_traj_pt_full.h
+++ b/simple_message/include/simple_message/joint_traj_pt_full.h
@@ -53,11 +53,11 @@ namespace SpecialSeqValues
 {
 enum SpecialSeqValue
 {
-  START_TRAJECTORY_DOWNLOAD  = -1,
+  START_TRAJECTORY_DOWNLOAD  = -1, ///< Downloading drivers only: signal start of trajectory
   START_TRAJECOTRY_STREAMING = -2, ///< deprecated, please use START_TRAJECTORY_STREAMING instead
-  START_TRAJECTORY_STREAMING = -2,
-  END_TRAJECTORY  = -3,
-  STOP_TRAJECTORY = -4
+  START_TRAJECTORY_STREAMING = -2, ///< Streaming drivers only: signal start of trajectory
+  END_TRAJECTORY  = -3, ///< Downloading drivers only: signal end of trajectory
+  STOP_TRAJECTORY = -4  ///< Server should stop the current motion (if any) as soon as possible
 };
 }
 typedef SpecialSeqValues::SpecialSeqValue SpecialSeqValue;


### PR DESCRIPTION
As per subject.

c5add37 fixes the typo (adds an additional enum member with corrected spelling) and marks the old one deprecated (comment only).

Added some Doxygen comments in 6871959.
