### PR TITLE
industrial_robot_client: Fix signature of goal and cancel callbacks.

### DIFF
--- a/industrial_robot_client/include/industrial_robot_client/joint_trajectory_action.h
+++ b/industrial_robot_client/include/industrial_robot_client/joint_trajectory_action.h
@@ -185,7 +185,7 @@ private:
    * \param gh goal handle
    *
    */
-  void goalCB(JointTractoryActionServer::GoalHandle & gh);
+  void goalCB(JointTractoryActionServer::GoalHandle gh);
 
   /**
    * \brief Action server cancel callback method
@@ -194,7 +194,7 @@ private:
    *
    */
 
-  void cancelCB(JointTractoryActionServer::GoalHandle & gh);
+  void cancelCB(JointTractoryActionServer::GoalHandle gh);
   /**
    * \brief Controller state callback (executed when feedback message
    * received)

--- a/industrial_robot_client/src/joint_trajectory_action.cpp
+++ b/industrial_robot_client/src/joint_trajectory_action.cpp
@@ -107,7 +107,7 @@ void JointTrajectoryAction::watchdog(const ros::TimerEvent &e)
   }
 }
 
-void JointTrajectoryAction::goalCB(JointTractoryActionServer::GoalHandle & gh)
+void JointTrajectoryAction::goalCB(JointTractoryActionServer::GoalHandle gh)
 {
   ROS_INFO("Received new goal");
 
@@ -180,7 +180,7 @@ void JointTrajectoryAction::goalCB(JointTractoryActionServer::GoalHandle & gh)
   }
 }
 
-void JointTrajectoryAction::cancelCB(JointTractoryActionServer::GoalHandle & gh)
+void JointTrajectoryAction::cancelCB(JointTractoryActionServer::GoalHandle gh)
 {
   ROS_DEBUG("Received action cancel request");
   if (active_goal_ == gh)


### PR DESCRIPTION
The goal and cancel callbacks of `ActionServer` take `GoalHandle`s by value [1], but the callbacks defined in `JointTrajectoryActionServer` took them by reference. I'm not sure why this compiled before C++11, but it doesn't now. Since g++ 6 compiles with C++11 support enabled by default, it is quite important to fix this.

Note that `GoalHandle` already acts like a reference type; it contains only (shared) pointers. So accepting them by value or by reference wont change the behaviour of the program.

[1] https://github.com/ros/actionlib/blob/da39083c513066e0d3d05346f3b1be9f9f90268d/include/actionlib/server/action_server.h#L87
