### PR TITLE
Fix for issue #137 (broken build badge link) & minor update to readme text

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,13 @@
 # Industrial Core
-[![Build Status](http://jenkins.ros.org/job/devel-indigo-industrial_core/badge/icon)](http://jenkins.ros.org/job/devel-indigo-industrial_core/)<BR>
+
+[![Build Status](http://build.ros.org/job/Idev__industrial_core__ubuntu_trusty_amd64/badge/icon)](http://build.ros.org/job/Idev__industrial_core__ubuntu_trusty_amd64)
+
 [ROS-Industrial][] core meta-package.  See the [ROS wiki][] page for more information.
 
 ## Contents
 
 This repo holds source code for all versions > groovy. For those versions <= groovy see: [SVN repo][]
+
 
 [ROS-Industrial]: http://www.ros.org/wiki/Industrial
 [ROS wiki]: http://ros.org/wiki/industrial_core

--- a/README.md
+++ b/README.md
@@ -2,13 +2,18 @@
 
 [![Build Status](http://build.ros.org/job/Idev__industrial_core__ubuntu_trusty_amd64/badge/icon)](http://build.ros.org/job/Idev__industrial_core__ubuntu_trusty_amd64)
 
-[ROS-Industrial][] core meta-package.  See the [ROS wiki][] page for more information.
+[ROS-Industrial][] core meta-package. See the [ROS wiki][] page for more
+information.
 
 ## Contents
 
-This repo holds source code for all versions > groovy. For those versions <= groovy see: [SVN repo][]
+Branch naming follows the ROS distribution they are compatible with. `-devel`
+branches may be unstable. Releases are made from the distribution branches
+(`hydro`, `indigo`, `jade`).
+
+Older releases may be found in the old ROS-Industrial [subversion repository][].
 
 
-[ROS-Industrial]: http://www.ros.org/wiki/Industrial
-[ROS wiki]: http://ros.org/wiki/industrial_core
-[SVN repo]: https://code.google.com/p/swri-ros-pkg/source/browse
+[ROS-Industrial]: http://wiki.ros.org/Industrial
+[ROS wiki]: http://wiki.ros.org/industrial_core
+[subversion repository]: https://github.com/ros-industrial/swri-ros-pkg


### PR DESCRIPTION
As per subject.

112e136 brings the text in the readme in this repository more in-line with the other industrial repositories.
