### PR TITLE
Use urdf::*ShredPtr instead of boost::shared_ptr

### DIFF
--- a/industrial_utils/CMakeLists.txt
+++ b/industrial_utils/CMakeLists.txt
@@ -6,14 +6,19 @@ find_package(catkin REQUIRED COMPONENTS roscpp urdf)
 
 find_package(Boost REQUIRED COMPONENTS system)
 
+find_package(urdfdom_headers 0.4 REQUIRED)
+
 catkin_package(
     CATKIN_DEPENDS roscpp urdf
     INCLUDE_DIRS include
     LIBRARIES ${PROJECT_NAME}
+    DEPENDS urdfdom_headers
 )
 
 include_directories(include
-  ${catkin_INCLUDE_DIRS})
+  ${catkin_INCLUDE_DIRS}
+  ${urdfdom_headers_INCLUDE_DIRS}
+  )
 
 add_library(${PROJECT_NAME} src/utils.cpp src/param_utils.cpp)
 target_link_libraries(${PROJECT_NAME} ${catkin_LIBRARIES})

--- a/industrial_utils/include/industrial_utils/utils.h
+++ b/industrial_utils/include/industrial_utils/utils.h
@@ -75,7 +75,7 @@ bool isSame(const std::vector<std::string> & lhs, const std::vector<std::string>
  *
  * \return true if successful, false if error occurred (e.g. branching tree)
  */
-bool findChainJointNames(const boost::shared_ptr<const urdf::Link> &link, bool ignore_fixed,
+bool findChainJointNames(const urdf::LinkConstSharedPtr &link, bool ignore_fixed,
 		                 std::vector<std::string> &joint_names);
 
 } //industrial_utils

--- a/industrial_utils/package.xml
+++ b/industrial_utils/package.xml
@@ -11,6 +11,8 @@
   <buildtool_depend>catkin</buildtool_depend>
   <build_depend>roscpp</build_depend>
   <build_depend>urdf</build_depend>
+  <build_depend version_gte="0.4">liburdfdom-headers-dev</build_depend>
   <run_depend>roscpp</run_depend>
   <run_depend>urdf</run_depend>
+  <run_depend version_gte="0.4">liburdfdom-headers-dev</run_depend>
 </package>

--- a/industrial_utils/src/param_utils.cpp
+++ b/industrial_utils/src/param_utils.cpp
@@ -35,6 +35,7 @@
 #include "industrial_utils/utils.h"
 #include "ros/ros.h"
 #include "urdf/model.h"
+#include <urdf_model/types.h>
 
 namespace industrial_utils
 {
@@ -135,7 +136,7 @@ bool getJointNames(const std::string joint_list_param, const std::string urdf_pa
 bool getJointVelocityLimits(const std::string urdf_param_name, std::map<std::string, double> &velocity_limits)
 {
   urdf::Model model;
-  std::map<std::string, boost::shared_ptr<urdf::Joint> >::iterator iter;
+  std::map<std::string, urdf::JointSharedPtr >::iterator iter;
 
   if (!ros::param::has(urdf_param_name) || !model.initParam(urdf_param_name))
     return false;
@@ -144,7 +145,7 @@ bool getJointVelocityLimits(const std::string urdf_param_name, std::map<std::str
   for (iter=model.joints_.begin(); iter!=model.joints_.end(); ++iter)
   {
     std::string joint_name(iter->first);
-    boost::shared_ptr<urdf::JointLimits> limits = iter->second->limits;
+    urdf::JointLimitsSharedPtr limits = iter->second->limits;
     if ( limits && (limits->velocity > 0) )
       velocity_limits.insert(std::pair<std::string,double>(joint_name,limits->velocity));
   }

--- a/industrial_utils/src/utils.cpp
+++ b/industrial_utils/src/utils.cpp
@@ -69,11 +69,11 @@ bool isSame(const std::vector<std::string> & lhs, const std::vector<std::string>
   return rtn;
 }
 
-bool findChainJointNames(const boost::shared_ptr<const urdf::Link> &link, bool ignore_fixed,
+bool findChainJointNames(const urdf::LinkConstSharedPtr &link, bool ignore_fixed,
 		                 std::vector<std::string> &joint_names)
 {
-  typedef std::vector<boost::shared_ptr<urdf::Joint> > joint_list;
-  typedef std::vector<boost::shared_ptr<urdf::Link> > link_list;
+  typedef std::vector<urdf::JointSharedPtr > joint_list;
+  typedef std::vector<urdf::LinkSharedPtr > link_list;
   std::string found_joint, found_link;
 
   // check for joints directly connected to this link


### PR DESCRIPTION
urdfdom_headers uses C++ std::shared_ptr. As it exports it as custom
*SharedPtr type, we can use the to stay compatible.
