### PR TITLE
robot_simulator: clarify err msg when controller_joint_names is missing.

### DIFF
--- a/industrial_robot_simulator/industrial_robot_simulator
+++ b/industrial_robot_simulator/industrial_robot_simulator
@@ -234,7 +234,7 @@ class IndustrialRobotSimulatorNode():
         def_joint_names = ["joint_1", "joint_2", "joint_3", "joint_4", "joint_5", "joint_6"]
         self.joint_names = rospy.get_param('controller_joint_names', def_joint_names)
         if len(self.joint_names) == 0:
-            rospy.logwarn("Joint list is empty, did you set controller_joint_name?")
+            rospy.logwarn("Joint list is empty, did you set the 'controller_joint_names' parameter?")
         rospy.loginfo("Simulating manipulator with %d joints: %s", len(self.joint_names), ", ".join(self.joint_names))
 
         # Setup initial joint positions


### PR DESCRIPTION
As per subject.
