### PR TITLE
robot_status: missing reply to SERVICE_REQUEST. 

### DIFF
--- a/industrial_robot_client/src/robot_status_relay_handler.cpp
+++ b/industrial_robot_client/src/robot_status_relay_handler.cpp
@@ -80,7 +80,7 @@ bool RobotStatusRelayHandler::internalCB(RobotStatusMessage & in)
   this->pub_robot_status_.publish(status);
 
   // Reply back to the controller if the sender requested it.
-  if (CommTypes::SERVICE_REQUEST == in.getMessageType())
+  if (CommTypes::SERVICE_REQUEST == in.getCommType())
   {
     SimpleMessage reply;
     in.toReply(reply, rtn ? ReplyTypes::SUCCESS : ReplyTypes::FAILURE);

--- a/simple_message/include/simple_message/messages/robot_status_message.h
+++ b/simple_message/include/simple_message/messages/robot_status_message.h
@@ -110,8 +110,38 @@ public:
   {
     return this->status_.byteLength();
   }
+  
+  /**
+   * \brief Gets the communication type of the message
+   * 
+   * \return the value of the comm_type parameter (refer to simple_message::CommTypes::CommType)
+   */
+  int getCommType() const
+  {
+    return comm_type_;
+  }
+  
 
   industrial::robot_status::RobotStatus status_;
+  
+protected:
+
+  /**
+   * \brief Sets the communication type of the message
+   *
+   * \param comm_type: value of the comm_type parameter (refer to simple_message::CommTypes::CommType)
+   */
+  void setCommType(int comm_type = industrial::simple_message::CommTypes::INVALID)
+  {
+    this->comm_type_ = comm_type;
+  }
+  
+private:
+  
+  /**
+   * \brief Communications type (see simple_message::CommTypes::CommType)
+   */
+  industrial::shared_types::shared_int comm_type_;
 
 
 };

--- a/simple_message/include/simple_message/messages/robot_status_message.h
+++ b/simple_message/include/simple_message/messages/robot_status_message.h
@@ -111,38 +111,8 @@ public:
     return this->status_.byteLength();
   }
   
-  /**
-   * \brief Gets the communication type of the message
-   * 
-   * \return the value of the comm_type parameter (refer to simple_message::CommTypes::CommType)
-   */
-  int getCommType() const
-  {
-    return comm_type_;
-  }
-  
 
   industrial::robot_status::RobotStatus status_;
-  
-protected:
-
-  /**
-   * \brief Sets the communication type of the message
-   *
-   * \param comm_type: value of the comm_type parameter (refer to simple_message::CommTypes::CommType)
-   */
-  void setCommType(int comm_type = industrial::simple_message::CommTypes::INVALID)
-  {
-    this->comm_type_ = comm_type;
-  }
-  
-private:
-  
-  /**
-   * \brief Communications type (see simple_message::CommTypes::CommType)
-   */
-  industrial::shared_types::shared_int comm_type_;
-
 
 };
 

--- a/simple_message/include/simple_message/typed_message.h
+++ b/simple_message/include/simple_message/typed_message.h
@@ -130,25 +130,45 @@ public:
     		industrial::simple_message::ReplyTypes::INVALID, data);
   }
   /**
-     * \brief gets message type (enumeration)
-     *
-     * \return message type
-     */
+   * \brief gets message type (enumeration)
+   *
+   * \return message type
+   */
   int getMessageType() const
   {
     return message_type_;
   }
+  
+  /**
+   * \brief Gets the communication type of the message
+   * 
+   * \return the value of the comm_type parameter (refer to simple_message::CommTypes::CommType)
+   */
+  int getCommType() const
+  {
+    return comm_type_;
+  }
 
 protected:
 
-/**
-     * \brief sets message type
-     *
-     * \return message type
-     */
+  /**
+   * \brief sets message type
+   *
+   * \return message type
+   */
   void setMessageType(int message_type = industrial::simple_message::StandardMsgTypes::INVALID)
   {
     this->message_type_ = message_type;
+  }
+  
+  /**
+   * \brief Sets the communication type of the message
+   *
+   * \param comm_type: value of the comm_type parameter (refer to simple_message::CommTypes::CommType)
+   */
+  void setCommType(int comm_type = industrial::simple_message::CommTypes::INVALID)
+  {
+    this->comm_type_ = comm_type;
   }
 
 private:
@@ -158,6 +178,11 @@ private:
    */
 
   int message_type_;
+    
+  /**
+   * \brief Communications type (see simple_message::CommTypes::CommType)
+   */
+  int comm_type_;
 
 };
 

--- a/simple_message/src/messages/robot_status_message.cpp
+++ b/simple_message/src/messages/robot_status_message.cpp
@@ -66,6 +66,7 @@ bool RobotStatusMessage::init(industrial::simple_message::SimpleMessage & msg)
   bool rtn = false;
   ByteArray data = msg.getData();
   this->init();
+  this->setCommType(msg.getCommType());
 
   if (data.unload(this->status_))
   {


### PR DESCRIPTION
Fix in robot_status_message and relay_handler.

Wrong condition check at line 83 of robot_status_relay_handler.cpp (comparing CommType with MessageType).
In order to fix this issue, I had to modify also the robot_status_message class, adding get\* and set\* methods for the comm_type attribute.
