### PR TITLE
Fix for issue #127  Uniform sample filter logging is too verbose

### DIFF
--- a/industrial_robot_client/src/joint_trajectory_action.cpp
+++ b/industrial_robot_client/src/joint_trajectory_action.cpp
@@ -51,6 +51,7 @@ JointTrajectoryAction::JointTrajectoryAction() :
 
   pn.param("constraints/goal_threshold", goal_threshold_, DEFAULT_GOAL_THRESHOLD_);
 
+
   if (!industrial_utils::param::getJointNames("controller_joint_names", "robot_description", joint_names_))
     ROS_ERROR("Failed to initialize joint_names.");
 
@@ -171,7 +172,7 @@ void JointTrajectoryAction::goalCB(JointTractoryActionServer::GoalHandle gh)
   }
   if (!gh.getGoal()->goal_tolerance.empty())
   {
-    ROS_WARN_STREAM(
+    ROS_ERROR_STREAM(
         "Ignoring goal tolerance in action, using paramater tolerance of " << goal_threshold_ << " instead");
   }
   if (!gh.getGoal()->path_tolerance.empty())

--- a/industrial_trajectory_filters/src/uniform_sample_filter.cpp
+++ b/industrial_trajectory_filters/src/uniform_sample_filter.cpp
@@ -82,13 +82,13 @@ template<typename T>
 
     while (interpolated_time < duration_in)
     {
-      ROS_INFO_STREAM("Interpolated time: " << interpolated_time);
+      ROS_DEBUG_STREAM("Interpolated time: " << interpolated_time);
       // Increment index until the interpolated time is past the start time.
       while (interpolated_time > trajectory_in.request.trajectory.points[index_in + 1].time_from_start.toSec())
       {
-        ROS_INFO_STREAM(
+        ROS_DEBUG_STREAM(
             "Interpolated time: " << interpolated_time << ", next point time: " << (trajectory_in.request.trajectory.points[index_in + 1].time_from_start.toSec()));
-        ROS_INFO_STREAM("Incrementing index");
+        ROS_DEBUG_STREAM("Incrementing index");
         index_in++;
         if (index_in >= size_in)
         {
@@ -134,7 +134,7 @@ template<typename T>
     double p1_time_from_start = p1.time_from_start.toSec();
     double p2_time_from_start = p2.time_from_start.toSec();
 
-    ROS_INFO_STREAM("time from start: " << time_from_start);
+    ROS_DEBUG_STREAM("time from start: " << time_from_start);
 
     if (time_from_start >= p1_time_from_start && time_from_start <= p2_time_from_start)
     {
@@ -150,7 +150,7 @@ template<typename T>
           // resample duration is less that the actual duration, which it might
           // be sometimes)
           KDL::VelocityProfile_Spline spline_calc;
-          ROS_INFO_STREAM( "---------------Begin interpolating joint point---------------");
+          ROS_DEBUG_STREAM( "---------------Begin interpolating joint point---------------");
 
           for (size_t i = 0; i < p1.positions.size(); ++i)
           {
@@ -158,30 +158,30 @@ template<typename T>
             double time_from_p1 = time_from_start - p1.time_from_start.toSec();
             double time_from_p1_to_p2 = p2_time_from_start - p1_time_from_start;
 
-            ROS_INFO_STREAM("time from p1: " << time_from_p1);
-            ROS_INFO_STREAM( "time_from_p1_to_p2: " << time_from_p1_to_p2);
+            ROS_DEBUG_STREAM("time from p1: " << time_from_p1);
+            ROS_DEBUG_STREAM( "time_from_p1_to_p2: " << time_from_p1_to_p2);
 
             spline_calc.SetProfileDuration(p1.positions[i], p1.velocities[i], p1.accelerations[i], p2.positions[i],
                                            p2.velocities[i], p2.accelerations[i], time_from_p1_to_p2);
 
             ros::Duration time_from_start_dur(time_from_start);
-            ROS_INFO_STREAM( "time from start_dur: " << time_from_start_dur);
+            ROS_DEBUG_STREAM( "time from start_dur: " << time_from_start_dur);
 
             interp_pt.time_from_start = time_from_start_dur;
             interp_pt.positions[i] = spline_calc.Pos(time_from_p1);
             interp_pt.velocities[i] = spline_calc.Vel(time_from_p1);
             interp_pt.accelerations[i] = spline_calc.Acc(time_from_p1);
 
-            ROS_INFO_STREAM(
+            ROS_DEBUG_STREAM(
                 "p1.pos: " << p1.positions[i] << ", vel: " << p1.velocities[i] << ", acc: " << p1.accelerations[i] << ", tfs: " << p1.time_from_start);
 
-            ROS_INFO_STREAM(
+            ROS_DEBUG_STREAM(
                 "p2.pos: " << p2.positions[i] << ", vel: " << p2.velocities[i] << ", acc: " << p2.accelerations[i] << ", tfs: " << p2.time_from_start);
 
-            ROS_INFO_STREAM(
+            ROS_DEBUG_STREAM(
                 "interp_pt.pos: " << interp_pt.positions[i] << ", vel: " << interp_pt.velocities[i] << ", acc: " << interp_pt.accelerations[i] << ", tfs: " << interp_pt.time_from_start);
           }
-          ROS_INFO_STREAM( "---------------End interpolating joint point---------------");
+          ROS_DEBUG_STREAM( "---------------End interpolating joint point---------------");
           rtn = true;
         }
         else


### PR DESCRIPTION

Changed all relevant ROS_INFO_STREAM macros to ROS_DEBUG_STREAM macros. Now the filter only outputs the summary at the end.

