### PR TITLE
Migrating to Kinetic, MoveIt! needs C++11

### DIFF
--- a/industrial_robot_client/CMakeLists.txt
+++ b/industrial_robot_client/CMakeLists.txt
@@ -133,7 +133,6 @@ add_executable(joint_trajectory_action
   src/joint_trajectory_action.cpp)
 target_link_libraries(joint_trajectory_action 
   industrial_robot_client ${catkin_LIBRARIES})
-add_dependencies(joint_trajectory_action industrial_robot_client_gencpp)
 
 ##########
 ## Test ##

--- a/industrial_trajectory_filters/CMakeLists.txt
+++ b/industrial_trajectory_filters/CMakeLists.txt
@@ -2,6 +2,11 @@ cmake_minimum_required(VERSION 2.8.3)
 
 project(industrial_trajectory_filters)
 
+if(CMAKE_COMPILER_IS_GNUCXX)
+    set(CMAKE_CXX_FLAGS "-std=c++11 ${CMAKE_CXX_FLAGS}")
+endif()
+
+
 find_package(catkin REQUIRED COMPONENTS moveit_ros_planning trajectory_msgs)
 
 catkin_package(


### PR DESCRIPTION
Industrial Core seems to compile under Kinetic, only once you force industrial_trajectory_filters to use C++11.