### PR TITLE
Addresses test failures documented in #41

### DIFF
--- a/simple_message/CMakeLists.txt
+++ b/simple_message/CMakeLists.txt
@@ -102,7 +102,7 @@ target_link_libraries(simple_message ${catkin_LIBRARIES})
 add_dependencies(simple_message ${industrial_msgs_EXPORTED_TARGETS})
 
 catkin_add_gtest(utest ${UTEST_SRC_FILES})
-set_target_properties(utest PROPERTIES COMPILE_DEFINITIONS "TEST_PORT_BASE=11000")
+set_target_properties(utest PROPERTIES COMPILE_DEFINITIONS "TEST_PORT_BASE=51000")
 target_link_libraries(utest simple_message)
 
 # ALTERNATIVE LIBRARY (DIFFERENT ENDIAN)
@@ -112,7 +112,7 @@ target_link_libraries(simple_message_bswap ${catkin_LIBRARIES})
 add_dependencies(simple_message_bswap ${industrial_msgs_EXPORTED_TARGETS})
 
 catkin_add_gtest(utest_byte_swapping ${UTEST_SRC_FILES})
-set_target_properties(utest_byte_swapping PROPERTIES COMPILE_DEFINITIONS "TEST_PORT_BASE=12000")
+set_target_properties(utest_byte_swapping PROPERTIES COMPILE_DEFINITIONS "TEST_PORT_BASE=52000")
 target_link_libraries(utest_byte_swapping simple_message_bswap)
 
 # ALTERNATIVE LIBRARY (64-bit floats)
@@ -122,11 +122,11 @@ target_link_libraries(simple_message_float64 ${catkin_LIBRARIES})
 add_dependencies(simple_message_float64 ${industrial_msgs_EXPORTED_TARGETS})
 
 catkin_add_gtest(utest_float64 ${UTEST_SRC_FILES})
-set_target_properties(utest_float64 PROPERTIES COMPILE_DEFINITIONS "TEST_PORT_BASE=13000;FLOAT64")
+set_target_properties(utest_float64 PROPERTIES COMPILE_DEFINITIONS "TEST_PORT_BASE=53000;FLOAT64")
 target_link_libraries(utest_float64 simple_message_float64)
 
 catkin_add_gtest(utest_udp ${UTEST_SRC_FILES})
-set_target_properties(utest_udp PROPERTIES COMPILE_DEFINITIONS "TEST_PORT_BASE=15000;UDP_TEST")
+set_target_properties(utest_udp PROPERTIES COMPILE_DEFINITIONS "TEST_PORT_BASE=55000;UDP_TEST")
 target_link_libraries(utest_udp simple_message)
 
 install(

--- a/simple_message/test/utest_message.cpp
+++ b/simple_message/test/utest_message.cpp
@@ -60,7 +60,7 @@ using namespace industrial::robot_status_message;
 // Useful for checking the packing and unpacking of message data.
 void messagePassing(TypedMessage &send, TypedMessage &recv)
 {
-  const int tcpPort = 11010;
+  const int tcpPort = TEST_PORT_BASE+401;
   char ipAddr[] = "127.0.0.1";
 
   TcpClient tcpClient;


### PR DESCRIPTION
Changed test port numbers to unused range in linux.  `utest_message` now uses port range defined by macros (addresses failure to init server socket).

I believe this has become more of an issue because tests are now executed in parallel.  In the pasts, tests were executed in a single thread and there wasn't a chance of tests fighting over the same port number.