### PR TITLE
Temporary fix, commented out disabled test to remove unstable build status

### DIFF
--- a/simple_message/test/utest.cpp
+++ b/simple_message/test/utest.cpp
@@ -488,6 +488,8 @@ spinFunc(void* arg)
   return NULL;
 }
 
+/*  Commenting out this test because build shows "unstable" with disabled tests
+// See https://github.com/ros-industrial/industrial_core/issues/149 for details
 TEST(DISABLED_MessageManagerSuite, tcp)
 {
   const int port = TEST_PORT_BASE + 201;
@@ -549,6 +551,7 @@ TEST(DISABLED_MessageManagerSuite, tcp)
 
   delete client;
 }
+*/
 
 // Run all the tests that were declared with TEST()
 int main(int argc, char **argv)


### PR DESCRIPTION
This is a temporary fix for #149.  I commented out the test instead of disabling it.  The end result is the same, the test is not executed.  This should clear up the unstable build issue.