### PR TITLE
Use urdf::*SharedPtr instead of boost::shared_ptr

### DIFF
--- a/industrial_utils/include/industrial_utils/utils.h
+++ b/industrial_utils/include/industrial_utils/utils.h
@@ -75,7 +75,7 @@ bool isSame(const std::vector<std::string> & lhs, const std::vector<std::string>
  *
  * \return true if successful, false if error occurred (e.g. branching tree)
  */
-bool findChainJointNames(const boost::shared_ptr<const urdf::Link> &link, bool ignore_fixed,
+bool findChainJointNames(const urdf::LinkConstSharedPtr &link, bool ignore_fixed,
 		                 std::vector<std::string> &joint_names);
 
 } //industrial_utils

--- a/industrial_utils/src/param_utils.cpp
+++ b/industrial_utils/src/param_utils.cpp
@@ -34,7 +34,7 @@
 #include "industrial_utils/param_utils.h"
 #include "industrial_utils/utils.h"
 #include "ros/ros.h"
-#include "urdf/model.h"
+#include <urdf/urdfdom_compatibility.h>
 
 namespace industrial_utils
 {
@@ -135,7 +135,7 @@ bool getJointNames(const std::string joint_list_param, const std::string urdf_pa
 bool getJointVelocityLimits(const std::string urdf_param_name, std::map<std::string, double> &velocity_limits)
 {
   urdf::Model model;
-  std::map<std::string, boost::shared_ptr<urdf::Joint> >::iterator iter;
+  std::map<std::string, urdf::JointSharedPtr >::iterator iter;
 
   if (!ros::param::has(urdf_param_name) || !model.initParam(urdf_param_name))
     return false;
@@ -144,7 +144,7 @@ bool getJointVelocityLimits(const std::string urdf_param_name, std::map<std::str
   for (iter=model.joints_.begin(); iter!=model.joints_.end(); ++iter)
   {
     std::string joint_name(iter->first);
-    boost::shared_ptr<urdf::JointLimits> limits = iter->second->limits;
+    urdf::JointLimitsSharedPtr limits = iter->second->limits;
     if ( limits && (limits->velocity > 0) )
       velocity_limits.insert(std::pair<std::string,double>(joint_name,limits->velocity));
   }

--- a/industrial_utils/src/utils.cpp
+++ b/industrial_utils/src/utils.cpp
@@ -69,11 +69,11 @@ bool isSame(const std::vector<std::string> & lhs, const std::vector<std::string>
   return rtn;
 }
 
-bool findChainJointNames(const boost::shared_ptr<const urdf::Link> &link, bool ignore_fixed,
+bool findChainJointNames(const urdf::LinkConstSharedPtr &link, bool ignore_fixed,
 		                 std::vector<std::string> &joint_names)
 {
-  typedef std::vector<boost::shared_ptr<urdf::Joint> > joint_list;
-  typedef std::vector<boost::shared_ptr<urdf::Link> > link_list;
+  typedef std::vector<urdf::JointSharedPtr > joint_list;
+  typedef std::vector<urdf::LinkSharedPtr > link_list;
   std::string found_joint, found_link;
 
   // check for joints directly connected to this link


### PR DESCRIPTION
urdfdom_headers uses C++ std::shared_ptr. As it exports it as a custom
*SharedPtr type, we can use them to stay compatible.