### PR TITLE
Fix for issue #157: don't depend on non-existing targets in ind_rob_sim build file

### DIFF
--- a/industrial_robot_simulator/CMakeLists.txt
+++ b/industrial_robot_simulator/CMakeLists.txt
@@ -15,9 +15,7 @@ catkin_package(
 
 if (CATKIN_ENABLE_TESTING)
   find_package(roslaunch REQUIRED)
-  roslaunch_add_file_check(launch
-    DEPENDENCIES
-      joint_trajectory_action)
+  roslaunch_add_file_check(launch)
 endif()
 
 #############


### PR DESCRIPTION
`joint_trajectory_action` is not a target as far as CMake is concerned at that point in the build. So we can't depend on it.

This is similar to https://github.com/ros-industrial/fanuc/pull/187.
