### PR TITLE
Export platform build flags to dependent catkin projects

### DIFF
--- a/industrial_robot_client/CMakeLists.txt
+++ b/industrial_robot_client/CMakeLists.txt
@@ -8,10 +8,6 @@ find_package(catkin REQUIRED COMPONENTS roscpp std_msgs sensor_msgs
 
 find_package(Boost REQUIRED COMPONENTS system thread)
 
-# The definition is copied from the CMakeList for the simple_message package.
-add_definitions(-DROS=1)           #build using ROS libraries
-add_definitions(-DLINUXSOCKETS=1)  #build using LINUX SOCKETS libraries
-
 set(SRC_FILES src/joint_relay_handler.cpp
               src/robot_status_relay_handler.cpp
               src/joint_trajectory_downloader.cpp
@@ -31,7 +27,6 @@ catkin_package(
       industrial_utils
     INCLUDE_DIRS include
     LIBRARIES ${PROJECT_NAME}_dummy
-    CFG_EXTRAS issue46_workaround.cmake
 )
 
 

--- a/simple_message/CMakeLists.txt
+++ b/simple_message/CMakeLists.txt
@@ -9,11 +9,11 @@ set(ROS_BUILD_STATIC_LIBS true)
 set(ROS_BUILD_SHARED_LIBS false)
 
 # The simple_message library is designed to cross compile on Ubuntu
-# and various robot controllers.  This requires conditionally compiling
-# certain functions and headers.  The definition below enables compiling
-# for a ROS node.
-add_definitions(-DROS=1)           #build using ROS libraries
-add_definitions(-DLINUXSOCKETS=1)  #use linux sockets for communication
+# and various robot controllers. This requires conditionally compiling
+# certain functions and headers. The default flags in the file included
+# here enable compiling for a ROS node. This file is also exported to
+# dependent packages via the `catkin_package` commmand.
+include(cmake/platform_build_flags.cmake)
 
 set(SRC_FILES src/byte_array.cpp
 	src/simple_message.cpp
@@ -71,7 +71,7 @@ catkin_package(
     CATKIN_DEPENDS roscpp industrial_msgs
     INCLUDE_DIRS include
     LIBRARIES ${PROJECT_NAME}_dummy
-    CFG_EXTRAS issue46_workaround.cmake
+    CFG_EXTRAS platform_build_flags.cmake issue46_workaround.cmake
 )
 
 

--- a/simple_message/cmake/platform_build_flags.cmake
+++ b/simple_message/cmake/platform_build_flags.cmake
@@ -1,0 +1,11 @@
+# Flags that control the conditional compilation of this library for use on different platforms. The
+# defaults set here will be exported to dependent projects via catkin. Dependent projects can use
+# cmake's `remove_definitions` command to change these defaults if desired.
+
+#Include code that interfaces with ROS
+add_definitions(-DROS)
+
+#Control which platform's underlying networking library is used by this package.
+#The package will not build unless one (and only one) of these definitions is set.
+add_definitions(-DLINUXSOCKETS)
+#add_definitions(-DMOTOPLUS)

--- a/simple_message/cmake/platform_build_flags.cmake
+++ b/simple_message/cmake/platform_build_flags.cmake
@@ -3,9 +3,16 @@
 # cmake's `remove_definitions` command to change these defaults if desired.
 
 #Include code that interfaces with ROS
-add_definitions(-DROS)
+add_definitions(-DSIMPLE_MESSAGE_USE_ROS)
 
 #Control which platform's underlying networking library is used by this package.
 #The package will not build unless one (and only one) of these definitions is set.
+add_definitions(-DSIMPLE_MESSAGE_LINUX)
+#add_definitions(-DSIMPLE_MESSAGE_MOTOPLUS)
+
+#--------------------------------------------------------------------------
+#Old definitions (deprecated in kinetic, to be removed in lunar or melodic)
+#--------------------------------------------------------------------------
+add_definitions(-DROS)
 add_definitions(-DLINUXSOCKETS)
 #add_definitions(-DMOTOPLUS)

--- a/simple_message/include/simple_message/log_wrapper.h
+++ b/simple_message/include/simple_message/log_wrapper.h
@@ -32,11 +32,11 @@
 #ifndef LOG_WRAPPER_H_
 #define LOG_WRAPPER_H_
 
-#ifdef ROS
+#ifdef SIMPLE_MESSAGE_USE_ROS
 #include "ros/ros.h"
 #endif
 
-#ifdef MOTOPLUS
+#ifdef SIMPLE_MESSAGE_MOTOPLUS
 #include "motoPlus.h"
 #endif
 
@@ -55,7 +55,7 @@ namespace log_wrapper
     
 
 // Define ROS if this library will execute under ROS
-#ifdef ROS
+#ifdef SIMPLE_MESSAGE_USE_ROS
 
 // The LOG_COMM redirects to debug in ROS because ROS has
 // debug filtering tools that allow the communications messages

--- a/simple_message/include/simple_message/robot_status.h
+++ b/simple_message/include/simple_message/robot_status.h
@@ -60,7 +60,7 @@ enum RobotMode
   MANUAL = 1, AUTO = 2,
 };
 
-#ifdef ROS
+#ifdef SIMPLE_MESSAGE_USE_ROS
 int toROSMsgEnum(RobotModes::RobotMode mode);
 #endif
 
@@ -85,7 +85,7 @@ enum TriState
   TS_FALSE = 0,   TS_OFF = 0,  TS_DISABLED = 0,  TS_LOW = 0
 };
 
-#ifdef ROS
+#ifdef SIMPLE_MESSAGE_USE_ROS
 int toROSMsgEnum(TriStates::TriState state);
 #endif
 

--- a/simple_message/include/simple_message/socket/simple_socket.h
+++ b/simple_message/include/simple_message/socket/simple_socket.h
@@ -42,7 +42,7 @@
 #include "smpl_msg_connection.h"
 #endif
 
-#ifdef LINUXSOCKETS
+#ifdef SIMPLE_MESSAGE_LINUX
 
 #include "sys/socket.h"
 #include "arpa/inet.h"
@@ -73,7 +73,7 @@
 
 #endif
 
-#ifdef MOTOPLUS
+#ifdef SIMPLE_MESSAGE_MOTOPLUS
 
 #include "motoPlus.h"
 

--- a/simple_message/include/simple_message/socket/tcp_socket.h
+++ b/simple_message/include/simple_message/socket/tcp_socket.h
@@ -40,7 +40,7 @@
 #include "shared_types.h"
 #endif
 
-#ifdef LINUXSOCKETS
+#ifdef SIMPLE_MESSAGE_LINUX
 #include "sys/socket.h"
 #include "netdb.h"
 #include "arpa/inet.h"
@@ -48,7 +48,7 @@
 #include "unistd.h"
 #endif
 
-#ifdef MOTOPLUS
+#ifdef SIMPLE_MESSAGE_MOTOPLUS
 #include "motoPlus.h"
 #endif
 

--- a/simple_message/include/simple_message/socket/udp_socket.h
+++ b/simple_message/include/simple_message/socket/udp_socket.h
@@ -42,7 +42,7 @@
 #include "smpl_msg_connection.h"
 #endif
 
-#ifdef LINUXSOCKETS
+#ifdef SIMPLE_MESSAGE_LINUX
 #include "sys/socket.h"
 #include "arpa/inet.h"
 #include "string.h"
@@ -50,7 +50,7 @@
 #include "unistd.h"
 #endif
 
-#ifdef MOTOPLUS
+#ifdef SIMPLE_MESSAGE_MOTOPLUS
 #include "motoPlus.h"
 #endif
 

--- a/simple_message/src/message_manager.cpp
+++ b/simple_message/src/message_manager.cpp
@@ -38,7 +38,7 @@
 #include "simple_message.h"
 #endif
 
-#ifdef ROS
+#ifdef SIMPLE_MESSAGE_USE_ROS
 #include "ros/ros.h"
 #else
 #include "unistd.h"
@@ -171,7 +171,7 @@ void MessageManager::spinOnce()
 int ms_per_clock;
 void mySleep(int sec)
 {
-#ifdef MOTOPLUS
+#ifdef SIMPLE_MESSAGE_MOTOPLUS
   if (ms_per_clock <= 0)
     ms_per_clock = mpGetRtc();
 
@@ -184,7 +184,7 @@ void mySleep(int sec)
 void MessageManager::spin()
 {
   LOG_INFO("Entering message manager spin loop");
-#ifdef ROS
+#ifdef SIMPLE_MESSAGE_USE_ROS
   while (ros::ok())
 #else
   while (true)

--- a/simple_message/src/robot_status.cpp
+++ b/simple_message/src/robot_status.cpp
@@ -38,7 +38,7 @@
 #include "log_wrapper.h"
 #endif
 
-#ifdef ROS
+#ifdef SIMPLE_MESSAGE_USE_ROS
 // Files below used to translate between ROS messages enums and
 // enums defined in this file
 #include "industrial_msgs/RobotMode.h"
@@ -55,7 +55,7 @@ namespace robot_status
 namespace RobotModes
 {
 
-#ifdef ROS
+#ifdef SIMPLE_MESSAGE_USE_ROS
 
 int toROSMsgEnum(RobotModes::RobotMode mode)
 {
@@ -83,7 +83,7 @@ int toROSMsgEnum(RobotModes::RobotMode mode)
 namespace TriStates
 {
 
-#ifdef ROS
+#ifdef SIMPLE_MESSAGE_USE_ROS
 
 int toROSMsgEnum(TriStates::TriState state)
 {

--- a/simple_message/src/simple_message.cpp
+++ b/simple_message/src/simple_message.cpp
@@ -37,7 +37,7 @@
 #include "log_wrapper.h"
 #endif
 
-#ifdef MOTOPLUS
+#ifdef SIMPLE_MESSAGE_MOTOPLUS
 #include "motoPlus.h"
 #endif
 

--- a/simple_message/src/smpl_msg_connection.cpp
+++ b/simple_message/src/smpl_msg_connection.cpp
@@ -39,7 +39,7 @@
 #include "byte_array.h"
 #endif
 
-#ifdef MOTOPLUS
+#ifdef SIMPLE_MESSAGE_MOTOPLUS
 #include "motoPlus.h"
 #endif
 


### PR DESCRIPTION
This fixes the problem from #188 by using the `CFG_EXTRAS` option of the `catkin_package` command to export default compiler definitions to all projects which depend on `simple_message`. It also addresses a few of the names mentioned in #65 by adding a `SIMPLE_MESSAGE_` prefix to the definitions.

The "documentation" of these definitions for package users is right now only in `CMakeLists.txt` and the new `platform_build_flags.cmake` file. Let me know if there is anywhere else it would be appropriate to note this behavior.