### PR TITLE
Feature Add: Interfaces check private namespaced ~robot_ip_address before public parameter.

### DIFF
--- a/industrial_robot_client/src/joint_trajectory_interface.cpp
+++ b/industrial_robot_client/src/joint_trajectory_interface.cpp
@@ -54,7 +54,9 @@ bool JointTrajectoryInterface::init(std::string default_ip, int default_port)
   int port;
 
   // override IP/port with ROS params, if available
-  ros::param::param<std::string>("robot_ip_address", ip, default_ip);
+  ros::param::param<std::string>("~robot_ip_address", ip, default_ip);
+  if (ip.empty())
+    ros::param::param<std::string>("robot_ip_address", ip, default_ip);
   ros::param::param<int>("~port", port, default_port);
 
   // check for valid parameter values

--- a/industrial_robot_client/src/robot_state_interface.cpp
+++ b/industrial_robot_client/src/robot_state_interface.cpp
@@ -54,7 +54,9 @@ bool RobotStateInterface::init(std::string default_ip, int default_port)
   int port;
 
   // override IP/port with ROS params, if available
-  ros::param::param<std::string>("robot_ip_address", ip, default_ip);
+  ros::param::param<std::string>("~robot_ip_address", ip, default_ip);
+  if (ip.empty())
+    ros::param::param<std::string>("robot_ip_address", ip, default_ip);
   ros::param::param<int>("~port", port, default_port);
 
   // check for valid parameter values


### PR DESCRIPTION
Currently, the robot_state_interface and joint_trajectory_interface look to the public parameter server to get the robot_ip_address parameter. This can cause problems with multiple robots (in my case, multiple subsystems) running on a single ROS system.

This change allows the interfaces to search for a private namespaced IP parameter before resorting to the public parameter. This preserves backwards compatibility while allowing for launch files to specify private parameters within a <node> tag.