### PR TITLE
release melodic-devel

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,17 +7,18 @@ notifications:
   email:
     on_success: always
     on_failure: always
-#    recipients:
-#      - jane@doe
 env:
   matrix:
     - USE_DEB=true  ROS_DISTRO="kinetic"   ROS_REPOSITORY_PATH=http://packages.ros.org/ros/ubuntu
     - USE_DEB=true  ROS_DISTRO="kinetic"   ROS_REPOSITORY_PATH=http://packages.ros.org/ros-shadow-fixed/ubuntu
+    - USE_DEB=true  ROS_DISTRO="melodic"   ROS_REPOSITORY_PATH=http://packages.ros.org/ros/ubuntu
+    - USE_DEB=true  ROS_DISTRO="melodic"   ROS_REPOSITORY_PATH=http://packages.ros.org/ros-shadow-fixed/ubuntu
 matrix:
   allow_failures:
     - env: USE_DEB=true  ROS_DISTRO="kinetic"   ROS_REPOSITORY_PATH=http://packages.ros.org/ros-shadow-fixed/ubuntu
+    - env: USE_DEB=true  ROS_DISTRO="melodic"   ROS_REPOSITORY_PATH=http://packages.ros.org/ros-shadow-fixed/ubuntu
 install:
   - git clone https://github.com/ros-industrial/industrial_ci.git .ci_config
 script: 
   - source .ci_config/travis.sh
-#  - source ./travis.sh  # Enable this when you have a package-local script 
+

--- a/industrial_trajectory_filters/include/industrial_trajectory_filters/filter_base.h
+++ b/industrial_trajectory_filters/include/industrial_trajectory_filters/filter_base.h
@@ -37,7 +37,7 @@
 #include "ros/console.h"
 #include "ros/ros.h"
 #include <moveit/planning_request_adapter/planning_request_adapter.h>
-#include <class_loader/class_loader.h>
+#include <class_loader/class_loader.hpp>
 
 namespace industrial_trajectory_filters
 {

--- a/industrial_trajectory_filters/src/add_smoothing_filter.cpp
+++ b/industrial_trajectory_filters/src/add_smoothing_filter.cpp
@@ -35,7 +35,7 @@
 /* Author: Chris Lewis */
 
 #include <moveit/planning_request_adapter/planning_request_adapter.h>
-#include <class_loader/class_loader.h>
+#include <class_loader/class_loader.hpp>
 
 #include <industrial_trajectory_filters/smoothing_trajectory_filter.h>
 #include <ros/ros.h>  // required for NodeHandle


### PR DESCRIPTION
the actual file changes were minor.  Changed <class_loader/class_loader.h> to <class_loader/class_loader.hpp> as per a compiler warning.

I haven't tested it on actual hardware, but it builds:

```
FROM osrf/ros:melodic-desktop-full-bionic

RUN apt-get update && apt-get install -y \
    ros-melodic-moveit \
    python-rosinstall \
    python-rosinstall-generator \
    python-wstool \
    build-essential \
    python-pip \
    nano \
    gdb \
    && rm -rf /var/lib/apt/lists/*

RUN pip install --upgrade pip

RUN pip install -U catkin_tools

RUN mkdir -p /root/ros_libs/src

WORKDIR /root/ros_libs/src

RUN git clone -b melodic-devel https://github.com/AustinDeric/industrial_core.git

WORKDIR /root/ros_libs/

RUN /bin/bash -c "source /opt/ros/melodic/setup.bash && catkin build && catkin install"

```