### PR TITLE
Trajectory filters: check output of update method

### DIFF
--- a/industrial_trajectory_filters/include/industrial_trajectory_filters/filter_base.h
+++ b/industrial_trajectory_filters/include/industrial_trajectory_filters/filter_base.h
@@ -241,7 +241,10 @@ template<typename T>
         trajectory_in.request.trajectory = robot_trajectory_in.joint_trajectory;
 
         // applying arm navigation filter to planned trajectory
-        p->update(trajectory_in, trajectory_out);
+        if(!p->update(trajectory_in, trajectory_out))
+        {
+          return false;
+        }
 
         // saving filtered trajectory into moveit message.
         robot_trajectory_out.joint_trajectory = trajectory_out.request.trajectory;


### PR DESCRIPTION
I recently ran into an issue with a trajectory filter (uniform sampling filter) which had been accidentally given a bad input trajectory such that the `update` method returned false. The `adaptAndPlan` method did not check the output of the `update` method which subsequently resulted in an exception being thrown elsewhere in the `move_group` code. This PR checks the call to the `update` method before continuing to write the new output trajectory to avoid issues later in the planning/execution pipeline