### PR TITLE
travis: catch up with industrial_ci improvements.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,24 +1,30 @@
 sudo: required 
 dist: trusty 
 language: generic 
-compiler:
-  - gcc
-notifications:
-  email:
-    on_success: always
-    on_failure: always
+
+cache:
+  directories:
+    - $HOME/.ccache
+
+git:
+  quiet: true
+
 env:
+  global:
+    - CCACHE_DIR=$HOME/.ccache
+    - ROS_REPO=ros
   matrix:
-    - USE_DEB=true  ROS_DISTRO="kinetic"   ROS_REPOSITORY_PATH=http://packages.ros.org/ros/ubuntu
-    - USE_DEB=true  ROS_DISTRO="kinetic"   ROS_REPOSITORY_PATH=http://packages.ros.org/ros-shadow-fixed/ubuntu
-    - USE_DEB=true  ROS_DISTRO="melodic"   ROS_REPOSITORY_PATH=http://packages.ros.org/ros/ubuntu
-    - USE_DEB=true  ROS_DISTRO="melodic"   ROS_REPOSITORY_PATH=http://packages.ros.org/ros-shadow-fixed/ubuntu
+    - ROS_DISTRO="kinetic"
+    - ROS_DISTRO="kinetic" ROS_REPO=ros-shadow-fixed
+    - ROS_DISTRO="melodic"
+    - ROS_DISTRO="melodic" ROS_REPO=ros-shadow-fixed
+
 matrix:
   allow_failures:
-    - env: USE_DEB=true  ROS_DISTRO="kinetic"   ROS_REPOSITORY_PATH=http://packages.ros.org/ros-shadow-fixed/ubuntu
-    - env: USE_DEB=true  ROS_DISTRO="melodic"   ROS_REPOSITORY_PATH=http://packages.ros.org/ros-shadow-fixed/ubuntu
-install:
-  - git clone https://github.com/ros-industrial/industrial_ci.git .ci_config
-script: 
-  - source .ci_config/travis.sh
+    - env: ROS_DISTRO="kinetic" ROS_REPO=ros-shadow-fixed
+    - env: ROS_DISTRO="melodic" ROS_REPO=ros-shadow-fixed
 
+install:
+  - git clone --quiet --depth=1 https://github.com/ros-industrial/industrial_ci.git .ci_config
+script: 
+  - .ci_config/travis.sh


### PR DESCRIPTION
As per subject.

Enabling `ccache` should speed up repeated builds.
