### PR TITLE
fix #225: incorrect return value if deserializing duration fails

### DIFF
--- a/simple_message/src/joint_traj_pt.cpp
+++ b/simple_message/src/joint_traj_pt.cpp
@@ -108,7 +108,6 @@ bool JointTrajPt::load(industrial::byte_array::ByteArray *buffer)
           rtn = false;
           LOG_ERROR("Failed to load joint traj pt. duration");
         }
-        rtn = true;
       }
       else
       {


### PR DESCRIPTION
As discussed in #225, the `JointTrajPt` will return `true` even if deserializing `duration` failed.
This is the smallest possible fix, just removing the line that incorrectly set `rtn=true`.