### PR TITLE
fix #228: correct off-by-one on debug output

### DIFF
--- a/industrial_robot_client/src/joint_trajectory_streamer.cpp
+++ b/industrial_robot_client/src/joint_trajectory_streamer.cpp
@@ -191,9 +191,9 @@ void JointTrajectoryStreamer::streamingThread()
         ROS_DEBUG("Sending joint trajectory point");
         if (this->connection_->sendAndReceiveMsg(msg, reply, false))
         {
+          this->current_point_++;
           ROS_INFO("Point[%d of %d] sent to controller",
                    this->current_point_, (int)this->current_traj_.size());
-          this->current_point_++;
         }
         else
           ROS_WARN("Failed sent joint point, will try again");


### PR DESCRIPTION
Trivial fix for debugging output.