### PR TITLE
Sync kinetic-devel with kinetic

### DIFF
--- a/industrial_core/CHANGELOG.rst
+++ b/industrial_core/CHANGELOG.rst
@@ -2,6 +2,10 @@
 Changelog for package industrial_core
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+Forthcoming
+-----------
+* No changes
+
 0.6.0 (2017-01-16)
 ------------------
 * Added C++ 11 compile option

--- a/industrial_core/CHANGELOG.rst
+++ b/industrial_core/CHANGELOG.rst
@@ -2,8 +2,8 @@
 Changelog for package industrial_core
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-Forthcoming
------------
+0.6.0 (2017-01-16)
+------------------
 * Added C++ 11 compile option
 * Contributors: Victor Lamoine
 

--- a/industrial_core/CHANGELOG.rst
+++ b/industrial_core/CHANGELOG.rst
@@ -2,8 +2,8 @@
 Changelog for package industrial_core
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-Forthcoming
------------
+0.7.0 (2019-02-12)
+------------------
 * No changes
 
 0.6.0 (2017-01-16)

--- a/industrial_core/CHANGELOG.rst
+++ b/industrial_core/CHANGELOG.rst
@@ -2,6 +2,11 @@
 Changelog for package industrial_core
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+Forthcoming
+-----------
+* Added C++ 11 compile option
+* Contributors: Victor Lamoine
+
 0.5.1 (2017-01-15)
 ------------------
 * No changes

--- a/industrial_core/package.xml
+++ b/industrial_core/package.xml
@@ -1,6 +1,6 @@
 <package>
   <name>industrial_core</name>
-  <version>0.6.0</version>
+  <version>0.7.0</version>
   <description>ROS-Industrial core stack contains packages and libraries for supporing industrial systems</description>
 
   <maintainer email="sedwards@swri.org">Shaun Edwards</maintainer>

--- a/industrial_core/package.xml
+++ b/industrial_core/package.xml
@@ -1,6 +1,6 @@
 <package>
   <name>industrial_core</name>
-  <version>0.5.1</version>
+  <version>0.6.0</version>
   <description>ROS-Industrial core stack contains packages and libraries for supporing industrial systems</description>
 
   <maintainer email="sedwards@swri.org">Shaun Edwards</maintainer>

--- a/industrial_deprecated/CHANGELOG.rst
+++ b/industrial_deprecated/CHANGELOG.rst
@@ -2,8 +2,8 @@
 Changelog for package industrial_deprecated
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-Forthcoming
------------
+0.6.0 (2017-01-16)
+------------------
 * Added C++ 11 compile option
 * Contributors: Victor Lamoine
 

--- a/industrial_deprecated/CHANGELOG.rst
+++ b/industrial_deprecated/CHANGELOG.rst
@@ -2,6 +2,10 @@
 Changelog for package industrial_deprecated
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+Forthcoming
+-----------
+* No changes
+
 0.6.0 (2017-01-16)
 ------------------
 * Added C++ 11 compile option

--- a/industrial_deprecated/CHANGELOG.rst
+++ b/industrial_deprecated/CHANGELOG.rst
@@ -2,8 +2,8 @@
 Changelog for package industrial_deprecated
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-Forthcoming
------------
+0.7.0 (2019-02-12)
+------------------
 * No changes
 
 0.6.0 (2017-01-16)

--- a/industrial_deprecated/CHANGELOG.rst
+++ b/industrial_deprecated/CHANGELOG.rst
@@ -2,6 +2,11 @@
 Changelog for package industrial_deprecated
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+Forthcoming
+-----------
+* Added C++ 11 compile option
+* Contributors: Victor Lamoine
+
 0.5.1 (2017-01-15)
 ------------------
 * No changes

--- a/industrial_deprecated/package.xml
+++ b/industrial_deprecated/package.xml
@@ -1,6 +1,6 @@
 <package>
   <name>industrial_deprecated</name>
-  <version>0.6.0</version>
+  <version>0.7.0</version>
   <description>
   The Industrial deprecated package contains nodes, launch files, etc... that are slated for 
   deprecation.  This package is the last place something will end up before being deleted.  

--- a/industrial_deprecated/package.xml
+++ b/industrial_deprecated/package.xml
@@ -1,6 +1,6 @@
 <package>
   <name>industrial_deprecated</name>
-  <version>0.5.1</version>
+  <version>0.6.0</version>
   <description>
   The Industrial deprecated package contains nodes, launch files, etc... that are slated for 
   deprecation.  This package is the last place something will end up before being deleted.  

--- a/industrial_msgs/CHANGELOG.rst
+++ b/industrial_msgs/CHANGELOG.rst
@@ -2,6 +2,11 @@
 Changelog for package industrial_msgs
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+Forthcoming
+-----------
+* Added C++ 11 compile option
+* Contributors: Victor Lamoine
+
 0.5.1 (2017-01-15)
 ------------------
 * No changes

--- a/industrial_msgs/CHANGELOG.rst
+++ b/industrial_msgs/CHANGELOG.rst
@@ -2,8 +2,8 @@
 Changelog for package industrial_msgs
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-Forthcoming
------------
+0.7.0 (2019-02-12)
+------------------
 * msgs: fix minor typo in RobotStatus comment. Fix `#186 <https://github.com/ros-industrial/industrial_core/issues/186>`_.
 * Contributors: G.A. vd. Hoorn, Levi Armstrong, Shaun Edwards
 

--- a/industrial_msgs/CHANGELOG.rst
+++ b/industrial_msgs/CHANGELOG.rst
@@ -2,8 +2,8 @@
 Changelog for package industrial_msgs
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-Forthcoming
------------
+0.6.0 (2017-01-16)
+------------------
 * Added C++ 11 compile option
 * Contributors: Victor Lamoine
 

--- a/industrial_msgs/CHANGELOG.rst
+++ b/industrial_msgs/CHANGELOG.rst
@@ -2,6 +2,11 @@
 Changelog for package industrial_msgs
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+Forthcoming
+-----------
+* msgs: fix minor typo in RobotStatus comment. Fix `#186 <https://github.com/ros-industrial/industrial_core/issues/186>`_.
+* Contributors: G.A. vd. Hoorn, Levi Armstrong, Shaun Edwards
+
 0.6.0 (2017-01-16)
 ------------------
 * Added C++ 11 compile option

--- a/industrial_msgs/package.xml
+++ b/industrial_msgs/package.xml
@@ -1,6 +1,6 @@
 <package>
   <name>industrial_msgs</name>
-  <version>0.6.0</version>
+  <version>0.7.0</version>
   <description>
 	The industrial message package containes industrial specific messages 
 	definitions. This package is part of the ROS-Industrial program.

--- a/industrial_msgs/package.xml
+++ b/industrial_msgs/package.xml
@@ -1,6 +1,6 @@
 <package>
   <name>industrial_msgs</name>
-  <version>0.5.1</version>
+  <version>0.6.0</version>
   <description>
 	The industrial message package containes industrial specific messages 
 	definitions. This package is part of the ROS-Industrial program.

--- a/industrial_robot_client/CHANGELOG.rst
+++ b/industrial_robot_client/CHANGELOG.rst
@@ -2,6 +2,20 @@
 Changelog for package industrial_robot_client
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+Forthcoming
+-----------
+* Decrease idle wait time.  250 ms is too slow. Fix `#214 <https://github.com/ros-industrial/industrial_core/issues/214>`_.
+* robot_client: add roslaunch testing. Fix `#208 <https://github.com/ros-industrial/industrial_core/issues/208>`_.
+* Removed `robot_state_visualization.launch`, as that would introduce a dependency on `rviz`. Fix `ros-industrial/ros_industrial_issues#50 <https://github.com/ros-industrial/ros_industrial_issues/issues/50>`_.
+* robot_client: add missing dependency on RSP. Fix `#209 <https://github.com/ros-industrial/industrial_core/issues/209>`_.
+* Updated the libraries install tags- follow the official documentation. Fix `#193 <https://github.com/ros-industrial/industrial_core/issues/193>`_.
+* Added missed test dependencies to rosunit. Fix `#205 <https://github.com/ros-industrial/industrial_core/issues/205>`_.
+* Using the 'doc' attribute on 'arg' elements. Added doc strings to all launch file args.
+* Merge branch 'kinetic-devel' into urdfdom_headers_fix
+* robot_client: make indenting consistent.
+* client: build unit tests conditionally
+* Contributors: Dmitry Rozhkov, G.A. vd. Hoorn, Harsh Deshpande, Levi Armstrong, Nadia Hammoudeh García, Patrick Beeson, Shaun Edwards, gavanderhoorn
+
 0.6.0 (2017-01-16)
 ------------------
 * Added C++ 11 compile option

--- a/industrial_robot_client/CHANGELOG.rst
+++ b/industrial_robot_client/CHANGELOG.rst
@@ -2,8 +2,8 @@
 Changelog for package industrial_robot_client
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-Forthcoming
------------
+0.7.0 (2019-02-12)
+------------------
 * Decrease idle wait time.  250 ms is too slow. Fix `#214 <https://github.com/ros-industrial/industrial_core/issues/214>`_.
 * robot_client: add roslaunch testing. Fix `#208 <https://github.com/ros-industrial/industrial_core/issues/208>`_.
 * Removed `robot_state_visualization.launch`, as that would introduce a dependency on `rviz`. Fix `ros-industrial/ros_industrial_issues#50 <https://github.com/ros-industrial/ros_industrial_issues/issues/50>`_.

--- a/industrial_robot_client/CHANGELOG.rst
+++ b/industrial_robot_client/CHANGELOG.rst
@@ -2,8 +2,8 @@
 Changelog for package industrial_robot_client
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-Forthcoming
------------
+0.6.0 (2017-01-16)
+------------------
 * Added C++ 11 compile option
 * Contributors: Victor Lamoine
 

--- a/industrial_robot_client/CHANGELOG.rst
+++ b/industrial_robot_client/CHANGELOG.rst
@@ -2,6 +2,11 @@
 Changelog for package industrial_robot_client
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+Forthcoming
+-----------
+* Added C++ 11 compile option
+* Contributors: Victor Lamoine
+
 0.5.1 (2017-01-15)
 ------------------
 * robot_status: missing reply to SERVICE_REQUEST. Fix in robot_status_message and relay_handler.

--- a/industrial_robot_client/package.xml
+++ b/industrial_robot_client/package.xml
@@ -1,6 +1,6 @@
 <package>
   <name>industrial_robot_client</name>
-  <version>0.6.0</version>
+  <version>0.7.0</version>
   <description>industrial robot client contains generic clients for connecting 
      to industrial robot controllers with servers that adhere to the
      simple message protocol.

--- a/industrial_robot_client/package.xml
+++ b/industrial_robot_client/package.xml
@@ -1,6 +1,6 @@
 <package>
   <name>industrial_robot_client</name>
-  <version>0.5.1</version>
+  <version>0.6.0</version>
   <description>industrial robot client contains generic clients for connecting 
      to industrial robot controllers with servers that adhere to the
      simple message protocol.

--- a/industrial_robot_simulator/CHANGELOG.rst
+++ b/industrial_robot_simulator/CHANGELOG.rst
@@ -2,6 +2,14 @@
 Changelog for package industrial_robot_simulator
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+Forthcoming
+-----------
+* Added in better simluation when velocities are provided for trajectory
+* robot_simulator: review and fix buildscript and manifest. Fix `#207 <https://github.com/ros-industrial/industrial_core/issues/207>`_.
+* Fix for issue `#157 <https://github.com/ros-industrial/industrial_core/issues/157>`_: don't depend on non-existing targets in ind_rob_sim build file
+* robot_sim: don't depend on targets that don't exist. Fix `#157 <https://github.com/ros-industrial/industrial_core/issues/157>`_.
+* Contributors: Levi Armstrong, Nadia Hammoudeh García, Patrick Beeson, Shaun Edwards, gavanderhoorn
+
 0.6.0 (2017-01-16)
 ------------------
 * Added C++ 11 compile option

--- a/industrial_robot_simulator/CHANGELOG.rst
+++ b/industrial_robot_simulator/CHANGELOG.rst
@@ -2,8 +2,8 @@
 Changelog for package industrial_robot_simulator
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-Forthcoming
------------
+0.7.0 (2019-02-12)
+------------------
 * Added in better simluation when velocities are provided for trajectory
 * robot_simulator: review and fix buildscript and manifest. Fix `#207 <https://github.com/ros-industrial/industrial_core/issues/207>`_.
 * Fix for issue `#157 <https://github.com/ros-industrial/industrial_core/issues/157>`_: don't depend on non-existing targets in ind_rob_sim build file

--- a/industrial_robot_simulator/CHANGELOG.rst
+++ b/industrial_robot_simulator/CHANGELOG.rst
@@ -2,6 +2,11 @@
 Changelog for package industrial_robot_simulator
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+Forthcoming
+-----------
+* Added C++ 11 compile option
+* Contributors: Victor Lamoine
+
 0.5.1 (2017-01-15)
 ------------------
 * robot_simulator: clarify err msg when controller_joint_names is missing.

--- a/industrial_robot_simulator/CHANGELOG.rst
+++ b/industrial_robot_simulator/CHANGELOG.rst
@@ -2,8 +2,8 @@
 Changelog for package industrial_robot_simulator
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-Forthcoming
------------
+0.6.0 (2017-01-16)
+------------------
 * Added C++ 11 compile option
 * Contributors: Victor Lamoine
 

--- a/industrial_robot_simulator/package.xml
+++ b/industrial_robot_simulator/package.xml
@@ -1,6 +1,6 @@
 <package format="2">
   <name>industrial_robot_simulator</name>
-  <version>0.5.1</version>
+  <version>0.6.0</version>
   <description>The industrial robot simulator is a stand in for industrial robot driver node(s).  It adheres to the driver specification for industrial robot controllers.</description>
 
   <maintainer email="sedwards@swri.org">Shaun Edwards</maintainer>

--- a/industrial_robot_simulator/package.xml
+++ b/industrial_robot_simulator/package.xml
@@ -1,6 +1,6 @@
 <package format="2">
   <name>industrial_robot_simulator</name>
-  <version>0.6.0</version>
+  <version>0.7.0</version>
   <description>The industrial robot simulator is a stand in for industrial robot driver node(s).  It adheres to the driver specification for industrial robot controllers.</description>
 
   <maintainer email="sedwards@swri.org">Shaun Edwards</maintainer>

--- a/industrial_trajectory_filters/CHANGELOG.rst
+++ b/industrial_trajectory_filters/CHANGELOG.rst
@@ -2,8 +2,8 @@
 Changelog for package industrial_trajectory_filters
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-Forthcoming
------------
+0.6.0 (2017-01-16)
+------------------
 * Added C++ 11 compile option
 * Contributors: Victor Lamoine
 

--- a/industrial_trajectory_filters/CHANGELOG.rst
+++ b/industrial_trajectory_filters/CHANGELOG.rst
@@ -2,8 +2,8 @@
 Changelog for package industrial_trajectory_filters
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-Forthcoming
------------
+0.7.0 (2019-02-12)
+------------------
 * Fix Melodic pluginlib incompatibility Fix `#204 <https://github.com/ros-industrial/industrial_core/issues/204>`_.
 * Fixed compiler warning while including class_loader.h (change to class_loader.hpp)
 * Updated filter base to return false when the update method returns false. Fix `#217 <https://github.com/ros-industrial/industrial_core/issues/217>`_.

--- a/industrial_trajectory_filters/CHANGELOG.rst
+++ b/industrial_trajectory_filters/CHANGELOG.rst
@@ -2,6 +2,11 @@
 Changelog for package industrial_trajectory_filters
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+Forthcoming
+-----------
+* Added C++ 11 compile option
+* Contributors: Victor Lamoine
+
 0.5.1 (2017-01-15)
 ------------------
 * Fix issue `#127 <https://github.com/ros-industrial/industrial_core/issues/127>`_

--- a/industrial_trajectory_filters/CHANGELOG.rst
+++ b/industrial_trajectory_filters/CHANGELOG.rst
@@ -2,6 +2,13 @@
 Changelog for package industrial_trajectory_filters
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+Forthcoming
+-----------
+* Fix Melodic pluginlib incompatibility Fix `#204 <https://github.com/ros-industrial/industrial_core/issues/204>`_.
+* Fixed compiler warning while including class_loader.h (change to class_loader.hpp)
+* Updated filter base to return false when the update method returns false. Fix `#217 <https://github.com/ros-industrial/industrial_core/issues/217>`_.
+* Contributors: Austin Deric, Levi Armstrong, Michael Ripperger
+
 0.6.0 (2017-01-16)
 ------------------
 * Added C++ 11 compile option

--- a/industrial_trajectory_filters/package.xml
+++ b/industrial_trajectory_filters/package.xml
@@ -1,6 +1,6 @@
 <package>
   <name>industrial_trajectory_filters</name>
-  <version>0.6.0</version>
+  <version>0.7.0</version>
   <description>
    <p>
      ROS Industrial libraries/plugins for filtering trajectories.

--- a/industrial_trajectory_filters/package.xml
+++ b/industrial_trajectory_filters/package.xml
@@ -1,6 +1,6 @@
 <package>
   <name>industrial_trajectory_filters</name>
-  <version>0.5.1</version>
+  <version>0.6.0</version>
   <description>
    <p>
      ROS Industrial libraries/plugins for filtering trajectories.

--- a/industrial_utils/CHANGELOG.rst
+++ b/industrial_utils/CHANGELOG.rst
@@ -2,6 +2,11 @@
 Changelog for package industrial_utils
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+Forthcoming
+-----------
+* Added C++ 11 compile option
+* Contributors: Victor Lamoine
+
 0.5.1 (2017-01-15)
 ------------------
 * No changes

--- a/industrial_utils/CHANGELOG.rst
+++ b/industrial_utils/CHANGELOG.rst
@@ -2,6 +2,16 @@
 Changelog for package industrial_utils
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+Forthcoming
+-----------
+* Added missed test dependencies to rosunit. Fix `#205 <https://github.com/ros-industrial/industrial_core/issues/205>`_
+* Reworded error displayed when joints cannot be found Fix `#180 <https://github.com/ros-industrial/industrial_core/issues/180>`_
+* Use urdf::*SharedPtr instead of boost::shared_ptr `#170 <https://github.com/ros-industrial/industrial_core/issues/170>`_
+* Fixed issue with urdfdom headers
+* Make building unit tests for client and utils conditional. Fix `#171 <https://github.com/ros-industrial/industrial_core/issues/171>`_.
+* Switched to urdf::*SharedPtr instead of boost::shared_ptr to stay compatible.
+* Contributors: Dmitry Rozhkov, G.A. vd. Hoorn, Jochen Sprickerhof, Levi Armstrong, Nadia Hammoudeh García, Shaun Edwards, ridhwanluthra
+
 0.6.0 (2017-01-16)
 ------------------
 * Added C++ 11 compile option

--- a/industrial_utils/CHANGELOG.rst
+++ b/industrial_utils/CHANGELOG.rst
@@ -2,8 +2,8 @@
 Changelog for package industrial_utils
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-Forthcoming
------------
+0.6.0 (2017-01-16)
+------------------
 * Added C++ 11 compile option
 * Contributors: Victor Lamoine
 

--- a/industrial_utils/CHANGELOG.rst
+++ b/industrial_utils/CHANGELOG.rst
@@ -2,8 +2,8 @@
 Changelog for package industrial_utils
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-Forthcoming
------------
+0.7.0 (2019-02-12)
+------------------
 * Added missed test dependencies to rosunit. Fix `#205 <https://github.com/ros-industrial/industrial_core/issues/205>`_
 * Reworded error displayed when joints cannot be found Fix `#180 <https://github.com/ros-industrial/industrial_core/issues/180>`_
 * Use urdf::*SharedPtr instead of boost::shared_ptr `#170 <https://github.com/ros-industrial/industrial_core/issues/170>`_

--- a/industrial_utils/package.xml
+++ b/industrial_utils/package.xml
@@ -1,6 +1,6 @@
 <package>
   <name>industrial_utils</name>
-  <version>0.6.0</version>
+  <version>0.7.0</version>
   <description>Industrial utils is a library package that captures common funcitonality for the ROS-Industrial distribution.</description>
 
   <maintainer email="sedwards@swri.org">Shaun Edwards</maintainer>

--- a/industrial_utils/package.xml
+++ b/industrial_utils/package.xml
@@ -1,6 +1,6 @@
 <package>
   <name>industrial_utils</name>
-  <version>0.5.1</version>
+  <version>0.6.0</version>
   <description>Industrial utils is a library package that captures common funcitonality for the ROS-Industrial distribution.</description>
 
   <maintainer email="sedwards@swri.org">Shaun Edwards</maintainer>

--- a/simple_message/CHANGELOG.rst
+++ b/simple_message/CHANGELOG.rst
@@ -2,6 +2,11 @@
 Changelog for package simple_message
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+Forthcoming
+-----------
+* Added C++ 11 compile option
+* Contributors: Victor Lamoine
+
 0.5.1 (2017-01-15)
 ------------------
 * Temporary fix, commented out disabled test to remove unstable build status

--- a/simple_message/CHANGELOG.rst
+++ b/simple_message/CHANGELOG.rst
@@ -2,8 +2,8 @@
 Changelog for package simple_message
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-Forthcoming
------------
+0.7.0 (2019-02-12)
+------------------
 * Updated the libraries install tags to follow the official documentation Fix `#193 <https://github.com/ros-industrial/industrial_core/issues/193>`_
 * simple_message: get rid of obsolete gethostbyname. Fix `#197 <https://github.com/ros-industrial/industrial_core/issues/197>`_
 * Added missed test dependencies to rosunit Fix `#205 <https://github.com/ros-industrial/industrial_core/issues/205>`_

--- a/simple_message/CHANGELOG.rst
+++ b/simple_message/CHANGELOG.rst
@@ -2,6 +2,15 @@
 Changelog for package simple_message
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+Forthcoming
+-----------
+* Updated the libraries install tags to follow the official documentation Fix `#193 <https://github.com/ros-industrial/industrial_core/issues/193>`_
+* simple_message: get rid of obsolete gethostbyname. Fix `#197 <https://github.com/ros-industrial/industrial_core/issues/197>`_
+* Added missed test dependencies to rosunit Fix `#205 <https://github.com/ros-industrial/industrial_core/issues/205>`_
+* Fixed issue 157 regarding non-existing targets
+* simple_message: build unit tests conditionally `#182 <https://github.com/ros-industrial/industrial_core/issues/182>`_
+* Contributors: Alexander Rössler, Dmitry Rozhkov, Levi Armstrong, Nadia Hammoudeh García, Shaun Edwards
+
 0.6.0 (2017-01-16)
 ------------------
 * Added C++ 11 compile option

--- a/simple_message/CHANGELOG.rst
+++ b/simple_message/CHANGELOG.rst
@@ -2,8 +2,8 @@
 Changelog for package simple_message
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-Forthcoming
------------
+0.6.0 (2017-01-16)
+------------------
 * Added C++ 11 compile option
 * Contributors: Victor Lamoine
 

--- a/simple_message/package.xml
+++ b/simple_message/package.xml
@@ -1,6 +1,6 @@
 <package>
   <name>simple_message</name>
-  <version>0.5.1</version>
+  <version>0.6.0</version>
   <description>
 	simple_message defines a simple messaging connection and protocol for communicating 
 	with an industrial robot controller.  Additional handler and manager classes are 

--- a/simple_message/package.xml
+++ b/simple_message/package.xml
@@ -1,6 +1,6 @@
 <package>
   <name>simple_message</name>
-  <version>0.6.0</version>
+  <version>0.7.0</version>
   <description>
 	simple_message defines a simple messaging connection and protocol for communicating 
 	with an industrial robot controller.  Additional handler and manager classes are 


### PR DESCRIPTION
This imports changes to changelogs and package manifests from the release branch into the `-devel` branch.

Fixes #224.

I would suggest to follow a slightly different workflow wrt releases in the future, where we update changelogs in the `-devel` branch and then sync that into the release branch. Releases would then still be done from the release branch, but it would avoid PRs to-and-from the release and `-devel` branches and keep history somewhat cleaner.
