### PR TITLE
Fix build with latest moveit's master branch

### DIFF
--- a/industrial_trajectory_filters/include/industrial_trajectory_filters/filter_base.h
+++ b/industrial_trajectory_filters/include/industrial_trajectory_filters/filter_base.h
@@ -172,6 +172,11 @@ template<typename T>
     }
     ; // original FilterBase method
 
+    /**
+     * Empty implementation of (later) pure virtual function
+     */
+    virtual void initialize(const ros::NodeHandle& node_handle) {}
+
   protected:
 
     /**

--- a/industrial_trajectory_filters/src/add_smoothing_filter.cpp
+++ b/industrial_trajectory_filters/src/add_smoothing_filter.cpp
@@ -123,7 +123,12 @@ public:
     }// end of if successful plan
     return result;
   };
-  
+
+  /*!
+   * Empty implementation of (later) pure virtual function
+   */
+  virtual void initialize(const ros::NodeHandle& node_handle) {};
+
 
 private:
   ros::NodeHandle nh_;


### PR DESCRIPTION
PlanningRequestAdapter::initialize() is now pure virtual so we have
to provide an empty implementation on each PlanningRequestAdapter subclass.

See also ros-planning/moveit#1621

Please be careful whether this patch breaks backward compatibility with older moveit builds (
where a virtual initialize() method is implemented and not pure virtual)