### PR TITLE
Rebased 199: always send trajectory stop request

### DIFF
--- a/industrial_robot_client/include/industrial_robot_client/joint_trajectory_streamer.h
+++ b/industrial_robot_client/include/industrial_robot_client/joint_trajectory_streamer.h
@@ -50,6 +50,15 @@ enum TransferState
 {
   IDLE = 0, STREAMING =1 //,STARTING, //, STOPPING
 };
+
+std::string to_string(TransferState state)
+{
+  if(state == TransferState::IDLE)
+    return "IDLE";
+  if(state == TransferState::STREAMING)
+    return "STREAMING";
+  return "UNKNOWN";
+}
 }
 typedef TransferStates::TransferState TransferState;
 

--- a/industrial_robot_client/src/joint_trajectory_streamer.cpp
+++ b/industrial_robot_client/src/joint_trajectory_streamer.cpp
@@ -80,11 +80,10 @@ void JointTrajectoryStreamer::jointTrajectoryCB(const trajectory_msgs::JointTraj
   if (msg->points.empty())
   {
     ROS_INFO("Empty trajectory received while in state: %d. Canceling current trajectory.", state);
-
     this->mutex_.lock();
-      trajectoryStop();
+    trajectoryStop();
     this->mutex_.unlock();
-      return;
+    return;
   }
 
   // if we're currently streaming a trajectory and we're requested to stream another
@@ -93,11 +92,10 @@ void JointTrajectoryStreamer::jointTrajectoryCB(const trajectory_msgs::JointTraj
   if (TransferStates::IDLE != state)
   {
     ROS_ERROR("Trajectory splicing not yet implemented, stopping current motion.");
-
     this->mutex_.lock();
-      trajectoryStop();
+    trajectoryStop();
     this->mutex_.unlock();
-      return;
+    return;
   }
 
   // calc new trajectory

--- a/industrial_robot_client/src/joint_trajectory_streamer.cpp
+++ b/industrial_robot_client/src/joint_trajectory_streamer.cpp
@@ -90,7 +90,7 @@ void JointTrajectoryStreamer::jointTrajectoryCB(const trajectory_msgs::JointTraj
   // if we're currently streaming a trajectory and we're requested to stream another
   // we complain, as splicing is not supported. Cancellation of the current trajectory
   // should first be requested, then a new trajectory started.
-  else if (TransferStates::IDLE != state)
+  if (TransferStates::IDLE != state)
   {
     ROS_ERROR("Trajectory splicing not yet implemented, stopping current motion.");
 

--- a/industrial_robot_client/src/joint_trajectory_streamer.cpp
+++ b/industrial_robot_client/src/joint_trajectory_streamer.cpp
@@ -68,7 +68,7 @@ void JointTrajectoryStreamer::jointTrajectoryCB(const trajectory_msgs::JointTraj
   ROS_INFO("Receiving joint trajectory message");
 
   // read current state value (should be atomic)
-  int state = this->state_;
+  const auto state = this->state_;
 
   ROS_DEBUG("Current state is: %d", state);
 
@@ -79,7 +79,7 @@ void JointTrajectoryStreamer::jointTrajectoryCB(const trajectory_msgs::JointTraj
   // would be "IDLE", and we'd end up not sending the stop request.
   if (msg->points.empty())
   {
-    ROS_INFO("Empty trajectory received while in state: %d. Canceling current trajectory.", state);
+    ROS_INFO_STREAM("Empty trajectory received while in state: " << TransferStates::to_string(state) << ". Canceling current trajectory.");
     this->mutex_.lock();
     trajectoryStop();
     this->mutex_.unlock();

--- a/industrial_robot_client/src/joint_trajectory_streamer.cpp
+++ b/industrial_robot_client/src/joint_trajectory_streamer.cpp
@@ -71,23 +71,25 @@ void JointTrajectoryStreamer::jointTrajectoryCB(const trajectory_msgs::JointTraj
   int state = this->state_;
 
   ROS_DEBUG("Current state is: %d", state);
-  if (TransferStates::IDLE != state)
-  {
-    if (msg->points.empty())
-      ROS_INFO("Empty trajectory received, canceling current trajectory");
-    else
-      ROS_ERROR("Trajectory splicing not yet implemented, stopping current motion.");
 
-	this->mutex_.lock();
-    trajectoryStop();
-	this->mutex_.unlock();
-    return;
-  }
-
+  // always stop the current trajectory if an empty trajectory is received
   if (msg->points.empty())
   {
-    ROS_INFO("Empty trajectory received while in IDLE state, nothing is done");
-    return;
+    ROS_INFO("Empty trajectory received while in state: %d. Canceling current trajectory.", state);
+
+    this->mutex_.lock();
+      trajectoryStop();
+    this->mutex_.unlock();
+      return;
+  }
+  else if (TransferStates::IDLE != state)
+  {
+    ROS_ERROR("Trajectory splicing not yet implemented, stopping current motion.");
+
+    this->mutex_.lock();
+      trajectoryStop();
+    this->mutex_.unlock();
+      return;
   }
 
   // calc new trajectory


### PR DESCRIPTION
Regardless of the state in which the trajectory streamer node is (ie: idle or not).

This is a rebase of #199 by @schornakj with some extra (cosmetic) commits.
