### PR TITLE
Rebased 238: TcpClient won't re-establish connection

### DIFF
--- a/simple_message/include/simple_message/socket/tcp_client.h
+++ b/simple_message/include/simple_message/socket/tcp_client.h
@@ -76,6 +76,9 @@ public:
     // Overrides
     bool makeConnect();
 
+private:
+    bool connectSocketHandle();
+
 
 };
 

--- a/simple_message/include/simple_message/socket/tcp_client.h
+++ b/simple_message/include/simple_message/socket/tcp_client.h
@@ -2,6 +2,7 @@
  * Software License Agreement (BSD License)
  *
  * Copyright (c) 2011, Southwest Research Institute
+ * Copyright (c) 2019, READY Robotics Corporation
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/simple_message/src/socket/tcp_client.cpp
+++ b/simple_message/src/socket/tcp_client.cpp
@@ -56,7 +56,7 @@ bool TcpClient::init(char *buff, int port_num)
   addrinfo *result;
   addrinfo hints = {};
 
-  if (!_connectSocketHandle())
+  if (!connectSocketHandle())
   {
     return false;
   }
@@ -89,10 +89,6 @@ bool TcpClient::init(char *buff, int port_num)
 
 bool TcpClient::makeConnect()
 {
-  bool rtn = false;
-  int rc = this->SOCKET_FAIL;
-  SOCKLEN_T addrSize = 0;
-
   if (isConnected())
   {
     LOG_WARN("Tried to connect when socket already in connected state");
@@ -118,7 +114,7 @@ bool TcpClient::makeConnect()
   return true;
 }
 
-bool TcpClient::_connectSocketHandle()
+bool TcpClient::connectSocketHandle()
 {
   if (isConnected())
   {

--- a/simple_message/src/socket/tcp_client.cpp
+++ b/simple_message/src/socket/tcp_client.cpp
@@ -2,6 +2,7 @@
  * Software License Agreement (BSD License)
  *
  * Copyright (c) 2011, Southwest Research Institute
+ * Copyright (c) 2019, READY Robotics Corporation
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/simple_message/src/socket/tcp_client.cpp
+++ b/simple_message/src/socket/tcp_client.cpp
@@ -53,56 +53,38 @@ TcpClient::~TcpClient()
 
 bool TcpClient::init(char *buff, int port_num)
 {
-
-  int rc;
-  bool rtn;
-  int disableNodeDelay = 1;
   addrinfo *result;
   addrinfo hints = {};
 
-  rc = SOCKET(AF_INET, SOCK_STREAM, 0);
-  if (this->SOCKET_FAIL != rc)
+  if (!_connectSocketHandle())
   {
-    this->setSockHandle(rc);
+    return false;
+  }
 
-    // The set no delay disables the NAGEL algorithm
-    rc = SET_NO_DELAY(this->getSockHandle(), disableNodeDelay);
-    if (this->SOCKET_FAIL == rc)
-    {
-      LOG_WARN("Failed to set no socket delay, sending data can be delayed by up to 250ms");
-    }
+  // Initialize address data structure
+  memset(&this->sockaddr_, 0, sizeof(this->sockaddr_));
+  this->sockaddr_.sin_family = AF_INET;
 
-    // Initialize address data structure
-    memset(&this->sockaddr_, 0, sizeof(this->sockaddr_));
-    this->sockaddr_.sin_family = AF_INET;
 
-    // Check for 'buff' as hostname, and use that, otherwise assume IP address
-    hints.ai_family = AF_INET;  // Allow IPv4
-    hints.ai_socktype = SOCK_STREAM;  // TCP socket
-    hints.ai_flags = 0;  // No flags
-    hints.ai_protocol = 0;  // Any protocol
-    hints.ai_canonname = NULL;
-    hints.ai_addr = NULL;
-    hints.ai_next = NULL;
-    if (0 == GETADDRINFO(buff, NULL, &hints, &result))
-    {
-      this->sockaddr_ = *((sockaddr_in *)result->ai_addr);
-    }
-    else 
-    {
-      this->sockaddr_.sin_addr.s_addr = INET_ADDR(buff);
-    }
-    this->sockaddr_.sin_port = HTONS(port_num);
-
-    rtn = true;
-
+  // Check for 'buff' as hostname, and use that, otherwise assume IP address
+  hints.ai_family = AF_INET;  // Allow IPv4
+  hints.ai_socktype = SOCK_STREAM;  // TCP socket
+  hints.ai_flags = 0;  // No flags
+  hints.ai_protocol = 0;  // Any protocol
+  hints.ai_canonname = NULL;
+  hints.ai_addr = NULL;
+  hints.ai_next = NULL;
+  if (0 == GETADDRINFO(buff, NULL, &hints, &result))
+  {
+    this->sockaddr_ = *((sockaddr_in *)result->ai_addr);
   }
   else
   {
-    LOG_ERROR("Failed to create socket, rc: %d", rc);
-    rtn = false;
+    this->sockaddr_.sin_addr.s_addr = INET_ADDR(buff);
   }
-  return rtn;
+  this->sockaddr_.sin_port = HTONS(port_num);
+
+  return true;
 }
 
 bool TcpClient::makeConnect()
@@ -111,32 +93,63 @@ bool TcpClient::makeConnect()
   int rc = this->SOCKET_FAIL;
   SOCKLEN_T addrSize = 0;
 
-  if (!this->isConnected())
-  {
-    addrSize = sizeof(this->sockaddr_);
-    rc = CONNECT(this->getSockHandle(), (sockaddr *)&this->sockaddr_, addrSize);
-    if (this->SOCKET_FAIL != rc)
-    {
-      LOG_INFO("Connected to server");
-      this->setConnected(true);
-      rtn = true;
-    }
-    else
-    {
-      this->logSocketError("Failed to connect to server", rc, errno);
-      rtn = false;
-    }
-  }
-
-  else
+  if (isConnected())
   {
     LOG_WARN("Tried to connect when socket already in connected state");
+    return false;
   }
 
-  return rtn;
+  if (!connectSocketHandle())
+  {
+    // Logging handled by connectSocketHandle()
+    return false;
+  }
 
+  int rc = CONNECT(this->getSockHandle(), (sockaddr *)&sockaddr_, sizeof(sockaddr_));
+  if (SOCKET_FAIL == rc)
+  {
+    logSocketError("Failed to connect to server", rc, errno);
+    return false;
+  }
+
+  LOG_INFO("Connected to server");
+  setConnected(true);
+
+  return true;
 }
 
+bool TcpClient::_connectSocketHandle()
+{
+  if (isConnected())
+  {
+    // Already connected, nothing to do
+    return true;
+  }
+
+  int sock_handle = getSockHandle();
+
+  if (sock_handle != SOCKET_FAIL)
+  {
+    // Handle is stale close old handle
+    CLOSE(sock_handle);
+  }
+
+  sock_handle = SOCKET(AF_INET, SOCK_STREAM, 0);
+  setSockHandle(sock_handle);
+  if (SOCKET_FAIL == sock_handle)
+  {
+    LOG_ERROR("Failed to create socket");
+    return false;
+  }
+
+  int disableNodeDelay = 1;
+  // The set no delay disables the NAGEL algorithm
+  if (SOCKET_FAIL == SET_NO_DELAY(sock_handle, disableNodeDelay))
+  {
+    LOG_WARN("Failed to set no socket delay, sending data can be delayed by up to 250ms");
+  }
+  return true;
+}
 } //tcp_client
 } //industrial
 


### PR DESCRIPTION
Rebased version of #238.

Got rid of the merge commits and tested against Roboguide on a different machine (which allowed me to 'disconnect' the controller by physically unplugging the cable).

The proposed changed do improve UX when it comes to handling dropped connections in the sense that the IRC nodes (and derived drivers) try to reconnect and can actually succeed.

*However*, the streaming trajectory relay actually drops traj pts when it loses connection. It claims to then "retry later", but it actually skips the point it dropped and continues with the next one in the trajectory. Before this change, that was not too much of a problem, as the connection would not come up again (requiring a restart, emptying queues and restarting everything).

With this change, it's possible for motion servers to immediately continue with the points they *do* receive (after the connection has been re-established), which is obviously less than ideal.

This PR is still an improvement though, so it'll be merged -- as soon as CI is green.

---

Edit: provenance and attribution retained for all commits.
