### PR TITLE
Rebased 233: catkin_lint all packages

### DIFF
--- a/industrial_msgs/CMakeLists.txt
+++ b/industrial_msgs/CMakeLists.txt
@@ -2,7 +2,7 @@ cmake_minimum_required(VERSION 3.0.2)
 
 project(industrial_msgs)
 
-find_package(catkin REQUIRED COMPONENTS std_msgs trajectory_msgs message_generation)
+find_package(catkin REQUIRED COMPONENTS message_generation std_msgs trajectory_msgs)
 
 add_message_files(
   FILES
@@ -23,9 +23,9 @@ add_service_files(
   StopMotion.srv)
 
 generate_messages(
-  DEPENDENCIES trajectory_msgs std_msgs
+  DEPENDENCIES std_msgs trajectory_msgs
 )
 
 catkin_package(
-    CATKIN_DEPENDS message_runtime std_msgs trajectory_msgs
+  CATKIN_DEPENDS message_runtime std_msgs trajectory_msgs
 )

--- a/industrial_robot_client/CMakeLists.txt
+++ b/industrial_robot_client/CMakeLists.txt
@@ -5,18 +5,18 @@ project(industrial_robot_client)
 set(CMAKE_CXX_STANDARD 11)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
-find_package(catkin REQUIRED COMPONENTS roscpp std_msgs sensor_msgs 
-  control_msgs trajectory_msgs simple_message actionlib_msgs actionlib 
-  urdf industrial_msgs industrial_utils)
+find_package(catkin REQUIRED COMPONENTS actionlib actionlib_msgs 
+  control_msgs industrial_msgs industrial_utils roscpp sensor_msgs  
+  simple_message std_msgs trajectory_msgs urdf)
 
 find_package(Boost REQUIRED COMPONENTS system thread)
 
 set(SRC_FILES src/joint_relay_handler.cpp
-              src/robot_status_relay_handler.cpp
               src/joint_trajectory_downloader.cpp
-              src/joint_trajectory_streamer.cpp
               src/joint_trajectory_interface.cpp
+              src/joint_trajectory_streamer.cpp
               src/robot_state_interface.cpp
+              src/robot_status_relay_handler.cpp
               src/utils.cpp)
 
 # NOTE: The libraries generated this package are not included in the catkin_package
@@ -25,9 +25,9 @@ set(SRC_FILES src/joint_relay_handler.cpp
 # library definitions (normal - industrial_robot_client and byteswapped.
 # industrial_robot_client_bswap) are both included (this is bad).
 catkin_package(
-    CATKIN_DEPENDS roscpp std_msgs sensor_msgs control_msgs trajectory_msgs
-      simple_message actionlib_msgs actionlib urdf industrial_msgs
-      industrial_utils
+    CATKIN_DEPENDS actionlib actionlib_msgs control_msgs 
+    industrial_msgs industrial_utils roscpp sensor_msgs 
+    simple_message std_msgs trajectory_msgs urdf
     INCLUDE_DIRS include
     LIBRARIES ${PROJECT_NAME}_dummy
     CFG_EXTRAS
@@ -71,14 +71,14 @@ install(TARGETS ${PROJECT_NAME}_dummy
 #    target_link_libraries(my_node industrial_robot_client_bswap)
 #
 
-add_library(industrial_robot_client ${SRC_FILES})
-target_link_libraries(industrial_robot_client ${catkin_LIBRARIES} simple_message)
-target_compile_definitions(industrial_robot_client PUBLIC
+add_library(${PROJECT_NAME} ${SRC_FILES})
+target_link_libraries(${PROJECT_NAME} ${catkin_LIBRARIES} simple_message)
+target_compile_definitions(${PROJECT_NAME} PUBLIC
   ${simple_message_DEFINITIONS})
 
-add_library(industrial_robot_client_bswap ${SRC_FILES})
-target_link_libraries(industrial_robot_client_bswap ${catkin_LIBRARIES} simple_message_bswap)
-target_compile_definitions(industrial_robot_client_bswap PUBLIC
+add_library(${PROJECT_NAME}_bswap ${SRC_FILES})
+target_link_libraries(${PROJECT_NAME}_bswap ${catkin_LIBRARIES} simple_message_bswap)
+target_compile_definitions(${PROJECT_NAME}_bswap PUBLIC
   ${simple_message_bswap_DEFINITIONS})
 
 # The following executables(nodes) are for applications where the robot
@@ -88,7 +88,7 @@ target_compile_definitions(industrial_robot_client_bswap PUBLIC
 add_executable(robot_state
   src/generic_robot_state_node.cpp)
 target_link_libraries(robot_state 
-  industrial_robot_client
+  ${PROJECT_NAME}
   simple_message
   ${catkin_LIBRARIES})
 target_compile_definitions(robot_state PRIVATE
@@ -97,7 +97,7 @@ target_compile_definitions(robot_state PRIVATE
 add_executable(motion_streaming_interface
   src/generic_joint_streamer_node.cpp)
 target_link_libraries(motion_streaming_interface 
-  industrial_robot_client 
+  ${PROJECT_NAME} 
   simple_message
   ${catkin_LIBRARIES})
 target_compile_definitions(motion_streaming_interface PRIVATE
@@ -106,7 +106,7 @@ target_compile_definitions(motion_streaming_interface PRIVATE
 add_executable(motion_download_interface
   src/generic_joint_downloader_node.cpp)
 target_link_libraries(motion_download_interface 
-  industrial_robot_client 
+  ${PROJECT_NAME} 
   simple_message
   ${catkin_LIBRARIES})
 target_compile_definitions(motion_download_interface PRIVATE
@@ -119,7 +119,7 @@ target_compile_definitions(motion_download_interface PRIVATE
 add_executable(robot_state_bswap
   src/generic_robot_state_node.cpp)
 target_link_libraries(robot_state_bswap 
-  industrial_robot_client_bswap 
+  ${PROJECT_NAME}_bswap 
   simple_message_bswap
   ${catkin_LIBRARIES})
 target_compile_definitions(robot_state_bswap PRIVATE
@@ -128,7 +128,7 @@ target_compile_definitions(robot_state_bswap PRIVATE
 add_executable(motion_streaming_interface_bswap
   src/generic_joint_streamer_node.cpp)
 target_link_libraries(motion_streaming_interface_bswap 
-  industrial_robot_client_bswap  
+  ${PROJECT_NAME}_bswap  
   simple_message_bswap
   ${catkin_LIBRARIES})
 target_compile_definitions(motion_streaming_interface_bswap PRIVATE
@@ -137,7 +137,7 @@ target_compile_definitions(motion_streaming_interface_bswap PRIVATE
 add_executable(motion_download_interface_bswap
   src/generic_joint_downloader_node.cpp)
 target_link_libraries(motion_download_interface_bswap 
-  industrial_robot_client_bswap  
+  ${PROJECT_NAME}_bswap  
   simple_message_bswap
   ${catkin_LIBRARIES})
 target_compile_definitions(motion_download_interface_bswap PRIVATE
@@ -151,7 +151,7 @@ add_executable(joint_trajectory_action
   src/generic_joint_trajectory_action_node.cpp
   src/joint_trajectory_action.cpp)
 target_link_libraries(joint_trajectory_action PRIVATE
-  industrial_robot_client ${catkin_LIBRARIES})
+  ${PROJECT_NAME} ${catkin_LIBRARIES})
 
 ##########
 ## Test ##
@@ -160,7 +160,7 @@ target_link_libraries(joint_trajectory_action PRIVATE
 if (CATKIN_ENABLE_TESTING)
   catkin_add_gtest(utest_robot_client test/utest.cpp)
   target_link_libraries(utest_robot_client
-    industrial_robot_client
+    ${PROJECT_NAME}
     ${catkin_LIBRARIES})
 endif()
 
@@ -179,19 +179,19 @@ endif()
 ##roslaunch_add_file_check(launch)
 
 install(
-    TARGETS industrial_robot_client industrial_robot_client_bswap
+    TARGETS ${PROJECT_NAME} ${PROJECT_NAME}_bswap
     ARCHIVE DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
     LIBRARY DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
     RUNTIME DESTINATION ${CATKIN_GLOBAL_BIN_DESTINATION})
 
 install(TARGETS 
-        robot_state 
-        robot_state_bswap 
+        joint_trajectory_action
+        motion_download_interface
+        motion_download_interface_bswap
         motion_streaming_interface 
-        motion_download_interface 
         motion_streaming_interface_bswap 
-        motion_download_interface_bswap 
-        joint_trajectory_action 
+        robot_state 
+        robot_state_bswap
     RUNTIME DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION})
 
 install(
@@ -201,5 +201,5 @@ install(
 foreach(dir config launch)
    install(DIRECTORY ${dir}/
       DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION}/${dir})
-endforeach(dir)
+endforeach()
 

--- a/industrial_robot_client/CMakeLists.txt
+++ b/industrial_robot_client/CMakeLists.txt
@@ -198,8 +198,6 @@ install(
 install(
   DIRECTORY include/${PROJECT_NAME}/
   DESTINATION ${CATKIN_PACKAGE_INCLUDE_DESTINATION})
-foreach(dir config launch)
-   install(DIRECTORY ${dir}/
-      DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION}/${dir})
-endforeach()
 
+install(DIRECTORY config launch
+  DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION})

--- a/industrial_robot_client/CMakeLists.txt
+++ b/industrial_robot_client/CMakeLists.txt
@@ -5,8 +5,8 @@ project(industrial_robot_client)
 set(CMAKE_CXX_STANDARD 11)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
-find_package(catkin REQUIRED COMPONENTS actionlib actionlib_msgs 
-  control_msgs industrial_msgs industrial_utils roscpp sensor_msgs  
+find_package(catkin REQUIRED COMPONENTS actionlib actionlib_msgs
+  control_msgs industrial_msgs industrial_utils roscpp sensor_msgs
   simple_message std_msgs trajectory_msgs urdf)
 
 find_package(Boost REQUIRED COMPONENTS system thread)
@@ -25,14 +25,14 @@ set(SRC_FILES src/joint_relay_handler.cpp
 # library definitions (normal - industrial_robot_client and byteswapped.
 # industrial_robot_client_bswap) are both included (this is bad).
 catkin_package(
-    CATKIN_DEPENDS actionlib actionlib_msgs control_msgs 
-    industrial_msgs industrial_utils roscpp sensor_msgs 
+  CATKIN_DEPENDS actionlib actionlib_msgs control_msgs
+    industrial_msgs industrial_utils roscpp sensor_msgs
     simple_message std_msgs trajectory_msgs urdf
-    INCLUDE_DIRS include
-    LIBRARIES ${PROJECT_NAME}_dummy
-    CFG_EXTRAS
-      issue46_workaround.cmake
-      platform_build_flags.cmake
+  INCLUDE_DIRS include
+  LIBRARIES ${PROJECT_NAME}_dummy
+  CFG_EXTRAS
+    issue46_workaround.cmake
+    platform_build_flags.cmake
 )
 
 
@@ -179,25 +179,25 @@ endif()
 ##roslaunch_add_file_check(launch)
 
 install(
-    TARGETS ${PROJECT_NAME} ${PROJECT_NAME}_bswap
-    ARCHIVE DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
-    LIBRARY DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
-    RUNTIME DESTINATION ${CATKIN_GLOBAL_BIN_DESTINATION})
-
-install(TARGETS 
-        joint_trajectory_action
-        motion_download_interface
-        motion_download_interface_bswap
-        motion_streaming_interface 
-        motion_streaming_interface_bswap 
-        robot_state 
-        robot_state_bswap
-    RUNTIME DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION})
+  TARGETS ${PROJECT_NAME} ${PROJECT_NAME}_bswap
+  ARCHIVE DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
+  LIBRARY DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
+  RUNTIME DESTINATION ${CATKIN_GLOBAL_BIN_DESTINATION})
 
 install(
-    DIRECTORY include/${PROJECT_NAME}/
-    DESTINATION ${CATKIN_PACKAGE_INCLUDE_DESTINATION})
+  TARGETS
+    joint_trajectory_action
+    motion_download_interface
+    motion_download_interface_bswap
+    motion_streaming_interface
+    motion_streaming_interface_bswap
+    robot_state
+    robot_state_bswap
+  RUNTIME DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION})
 
+install(
+  DIRECTORY include/${PROJECT_NAME}/
+  DESTINATION ${CATKIN_PACKAGE_INCLUDE_DESTINATION})
 foreach(dir config launch)
    install(DIRECTORY ${dir}/
       DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION}/${dir})

--- a/industrial_robot_client/package.xml
+++ b/industrial_robot_client/package.xml
@@ -28,6 +28,9 @@
   <depend>urdf</depend>
 
   <exec_depend>robot_state_publisher</exec_depend>
+  <!-- TODO: decide whether we want to introduce this exec_depend, as it would
+       drag in UI dependencies where the rest of IRC doesn't need it -->
+  <!-- <exec_depend>rviz</exec_depend> -->
 
   <test_depend>roslaunch</test_depend>
   <test_depend>rosunit</test_depend>

--- a/industrial_robot_client/package.xml
+++ b/industrial_robot_client/package.xml
@@ -29,5 +29,6 @@
 
   <exec_depend>robot_state_publisher</exec_depend>
 
+  <test_depend>roslaunch</test_depend>
   <test_depend>rosunit</test_depend>
 </package>

--- a/industrial_robot_client/package.xml
+++ b/industrial_robot_client/package.xml
@@ -15,17 +15,19 @@
 
   <buildtool_depend>catkin</buildtool_depend>
 
-  <depend>roscpp</depend>
-  <depend>std_msgs</depend>
-  <depend>sensor_msgs</depend>
-  <depend>control_msgs</depend>
-  <depend>trajectory_msgs</depend>
-  <depend>simple_message</depend>
   <depend>actionlib_msgs</depend>
   <depend>actionlib</depend>
-  <depend>urdf</depend>
+  <depend>control_msgs</depend>
   <depend>industrial_msgs</depend>
   <depend>industrial_utils</depend>
+  <depend>roscpp</depend>
+  <depend>sensor_msgs</depend>
+  <depend>simple_message</depend>
+  <depend>std_msgs</depend>
+  <depend>trajectory_msgs</depend>
+  <depend>urdf</depend>
+
   <exec_depend>robot_state_publisher</exec_depend>
+
   <test_depend>rosunit</test_depend>
 </package>

--- a/industrial_robot_simulator/CMakeLists.txt
+++ b/industrial_robot_simulator/CMakeLists.txt
@@ -19,7 +19,6 @@ endif()
 ## Install ##
 #############
 
-
-catkin_install_python(PROGRAMS industrial_robot_simulator DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION})
+catkin_install_python(PROGRAMS ${PROJECT_NAME} DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION})
 
 install(DIRECTORY launch/ DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION}/launch)

--- a/industrial_trajectory_filters/CMakeLists.txt
+++ b/industrial_trajectory_filters/CMakeLists.txt
@@ -17,11 +17,11 @@ include_directories(include
 )
 
 
-add_library(${PROJECT_NAME} 
-  src/n_point_filter.cpp 
-  src/uniform_sample_filter.cpp
+add_library(${PROJECT_NAME}
   src/add_smoothing_filter.cpp
+  src/n_point_filter.cpp
   src/smoothing_trajectory_filter.cpp
+  src/uniform_sample_filter.cpp
 )
 target_link_libraries(${PROJECT_NAME} ${catkin_LIBRARIES})
 

--- a/industrial_trajectory_filters/CMakeLists.txt
+++ b/industrial_trajectory_filters/CMakeLists.txt
@@ -4,10 +4,21 @@ project(industrial_trajectory_filters)
 
 add_compile_options(-std=c++11)
 
-find_package(catkin REQUIRED COMPONENTS moveit_ros_planning trajectory_msgs)
+find_package(catkin REQUIRED COMPONENTS
+  class_loader
+  moveit_core
+  moveit_ros_planning
+  pluginlib
+  trajectory_msgs
+)
 
 catkin_package(
-    CATKIN_DEPENDS moveit_ros_planning trajectory_msgs
+    CATKIN_DEPENDS
+      class_loader
+      moveit_core
+      moveit_ros_planning
+      pluginlib
+      trajectory_msgs
     INCLUDE_DIRS include
     LIBRARIES ${PROJECT_NAME}
 )

--- a/industrial_trajectory_filters/CMakeLists.txt
+++ b/industrial_trajectory_filters/CMakeLists.txt
@@ -12,6 +12,8 @@ find_package(catkin REQUIRED COMPONENTS
   trajectory_msgs
 )
 
+find_package(orocos_kdl REQUIRED)
+
 catkin_package(
     CATKIN_DEPENDS
       class_loader
@@ -21,10 +23,12 @@ catkin_package(
       trajectory_msgs
     INCLUDE_DIRS include
     LIBRARIES ${PROJECT_NAME}
+    DEPENDS orocos_kdl
 )
 
 include_directories(include
   ${catkin_INCLUDE_DIRS}
+  ${orocos_kdl_INCLUDE_DIRS}
 )
 
 
@@ -34,7 +38,7 @@ add_library(${PROJECT_NAME}
   src/smoothing_trajectory_filter.cpp
   src/uniform_sample_filter.cpp
 )
-target_link_libraries(${PROJECT_NAME} ${catkin_LIBRARIES})
+target_link_libraries(${PROJECT_NAME} ${catkin_LIBRARIES} ${orocos_kdl_LIBRARIES})
 
 
 install(TARGETS ${PROJECT_NAME}

--- a/industrial_trajectory_filters/package.xml
+++ b/industrial_trajectory_filters/package.xml
@@ -25,6 +25,7 @@
 
   <build_depend>liborocos-kdl-dev</build_depend>
 
+  <depend>class_loader</depend>
   <depend>liborocos-kdl</depend>
   <depend>moveit_core</depend>
   <depend>moveit_ros_planning</depend>

--- a/industrial_trajectory_filters/package.xml
+++ b/industrial_trajectory_filters/package.xml
@@ -25,11 +25,11 @@
 
   <build_depend>liborocos-kdl-dev</build_depend>
 
-  <depend>trajectory_msgs</depend>
-  <depend>pluginlib</depend>
+  <depend>liborocos-kdl</depend>
   <depend>moveit_core</depend>
   <depend>moveit_ros_planning</depend>
-  <depend>liborocos-kdl</depend>
+  <depend>pluginlib</depend>
+  <depend>trajectory_msgs</depend>
 
   <export>	
     <moveit_core plugin="${prefix}/planning_request_adapters_plugin_description.xml"/> 

--- a/industrial_trajectory_filters/package.xml
+++ b/industrial_trajectory_filters/package.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <?xml-model href="http://download.ros.org/schema/package_format2.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
-<package format="2">
+<package format="3">
   <name>industrial_trajectory_filters</name>
   <version>0.7.1</version>
   <description>
@@ -23,12 +23,14 @@
 
   <buildtool_depend>catkin</buildtool_depend>
 
-  <build_depend>liborocos-kdl-dev</build_depend>
+  <build_depend condition="$ROS_DISTRO == noetic">liborocos-kdl-dev</build_depend>
+  <build_export_depend condition="$ROS_DISTRO == noetic">liborocos-kdl-dev</build_export_depend>
+  <exec_depend condition="$ROS_DISTRO == noetic">liborocos-kdl</exec_depend>
 
   <depend>class_loader</depend>
-  <depend>liborocos-kdl</depend>
   <depend>moveit_core</depend>
   <depend>moveit_ros_planning</depend>
+  <depend condition="$ROS_DISTRO == melodic">orocos_kdl</depend>
   <depend>pluginlib</depend>
   <depend>trajectory_msgs</depend>
 

--- a/industrial_utils/CMakeLists.txt
+++ b/industrial_utils/CMakeLists.txt
@@ -15,7 +15,7 @@ catkin_package(
 include_directories(include
   ${catkin_INCLUDE_DIRS})
 
-add_library(${PROJECT_NAME} src/utils.cpp src/param_utils.cpp)
+add_library(${PROJECT_NAME} src/param_utils.cpp src/utils.cpp)
 target_link_libraries(${PROJECT_NAME} ${catkin_LIBRARIES})
 
 

--- a/simple_message/CMakeLists.txt
+++ b/simple_message/CMakeLists.txt
@@ -51,28 +51,28 @@ set(SRC_FILES src/byte_array.cpp
 	src/smpl_msg_connection.cpp
 
 	src/socket/simple_socket.cpp
-	src/socket/udp_socket.cpp
-	src/socket/udp_client.cpp
-	src/socket/udp_server.cpp
-	src/socket/tcp_socket.cpp
 	src/socket/tcp_client.cpp
 	src/socket/tcp_server.cpp
+	src/socket/tcp_socket.cpp
+	src/socket/udp_client.cpp
+	src/socket/udp_server.cpp
+	src/socket/udp_socket.cpp
 
+	src/joint_data.cpp
+	src/joint_feedback.cpp
+	src/joint_traj_pt_full.cpp
+	src/joint_traj_pt.cpp
+	src/joint_traj.cpp
 	src/message_handler.cpp
 	src/message_manager.cpp
 	src/ping_handler.cpp
 	src/ping_message.cpp
-	src/joint_data.cpp
-	src/joint_feedback.cpp
-	src/joint_traj_pt.cpp
-	src/joint_traj_pt_full.cpp
-	src/joint_traj.cpp
 	src/robot_status.cpp
 
-	src/messages/joint_message.cpp
 	src/messages/joint_feedback_message.cpp
-	src/messages/joint_traj_pt_message.cpp
+	src/messages/joint_message.cpp
 	src/messages/joint_traj_pt_full_message.cpp
+	src/messages/joint_traj_pt_message.cpp
 	src/messages/robot_status_message.cpp
 
 	src/simple_comms_fault_handler.cpp
@@ -90,6 +90,7 @@ add_library(${PROJECT_NAME}_dummy ${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}_du
 
 
 # DEFAULT LIBRARY (SAME ENDIAN)
+#catkin_lint: ignore_once unsorted_list
 add_library(${PROJECT_NAME} ${SRC_FILES})
 # NOTE: keep these in-sync with the lists in 'cmake/platform_build_flags.cmake'.
 # Yes, we could have used get_target_property(..) and then configure_file(..)
@@ -102,6 +103,7 @@ target_link_libraries(${PROJECT_NAME} $<$<BOOL:${WIN32}>:Ws2_32.lib>)
 add_dependencies(${PROJECT_NAME} ${industrial_msgs_EXPORTED_TARGETS})
 
 # ALTERNATIVE LIBRARY (DIFFERENT ENDIAN)
+#catkin_lint: ignore_once unsorted_list
 add_library(${PROJECT_NAME}_bswap ${SRC_FILES})
 # NOTE: keep these in-sync with the lists in 'cmake/platform_build_flags.cmake'
 target_compile_definitions(${PROJECT_NAME}_bswap PUBLIC
@@ -111,6 +113,7 @@ target_link_libraries(${PROJECT_NAME}_bswap $<$<BOOL:${WIN32}>:Ws2_32.lib>)
 add_dependencies(${PROJECT_NAME}_bswap ${industrial_msgs_EXPORTED_TARGETS})
 
 # ALTERNATIVE LIBRARY (64-bit floats)
+#catkin_lint: ignore_once unsorted_list
 add_library(${PROJECT_NAME}_float64 ${SRC_FILES})
 # NOTE: keep these in-sync with the lists in 'cmake/platform_build_flags.cmake'
 target_compile_definitions(${PROJECT_NAME}_float64 PUBLIC

--- a/simple_message/CMakeLists.txt
+++ b/simple_message/CMakeLists.txt
@@ -46,6 +46,7 @@ include_directories(include
 set(ROS_BUILD_STATIC_LIBS true)
 set(ROS_BUILD_SHARED_LIBS false)
 
+#catkin_lint: ignore_once literal_project_name
 set(SRC_FILES src/byte_array.cpp
 	src/simple_message.cpp
 	src/smpl_msg_connection.cpp

--- a/simple_message/CMakeLists.txt
+++ b/simple_message/CMakeLists.txt
@@ -5,7 +5,42 @@ project(simple_message)
 set(CMAKE_CXX_STANDARD 11)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
-find_package(catkin REQUIRED COMPONENTS roscpp industrial_msgs)
+find_package(catkin REQUIRED COMPONENTS industrial_msgs roscpp)
+
+# The simple message make file builds three libraries: simple_message,
+# simple_message_bswap and simple_message_float64.
+#
+# simple_message - is the default library.  This library should be used
+# when the target for the simple message is the same endian (i.e. both
+# big-endian or little-endian).  Intel based machines are little endian
+#
+# simple_message_bswap - is an alternative library that can be used
+# when the target for simple message is a DIFFERENT endian AND when the target
+# target cannot perform byte swapping (as is the case for some industrial
+# controllers).  This library performs byte swapping at the lowest load/unload
+# levels.
+#
+# simple_message_float64 - another alternative which uses 8 byte floats instead
+# of 4 byte floats (ie: double precision vs single precision).
+# This variant changes the shared_float typedef everywhere to be 8 byte floats.
+#
+# NOTE: The libraries generated this package are not included in the catkin_package
+# macro because libraries must be explicitly linked in projects that depend on this
+# package.  If this is not done (and these libraries were exported), then multiple
+# library definitions (normal - simple_message, byteswapped - simple_message_bswap
+# and simple_message_float64) are all included (this is bad).
+catkin_package(
+    CATKIN_DEPENDS industrial_msgs roscpp
+    INCLUDE_DIRS include
+    LIBRARIES ${PROJECT_NAME}_dummy
+    CFG_EXTRAS
+      issue46_workaround.cmake
+      platform_build_flags.cmake
+)
+
+include_directories(include
+  ${catkin_INCLUDE_DIRS}
+)
 
 # Build static libs, to reduce dependency-chaining for industrial_robot_client
 set(ROS_BUILD_STATIC_LIBS true)
@@ -40,47 +75,10 @@ set(SRC_FILES src/byte_array.cpp
 	src/messages/joint_traj_pt_full_message.cpp
 	src/messages/robot_status_message.cpp
 
-	src/simple_comms_fault_handler.cpp)
-					
+	src/simple_comms_fault_handler.cpp
+)
+
 set(UTEST_SRC_FILES test/utest.cpp test/utest_message.cpp)
-
-# The simple message make file builds three libraries: simple_message,
-# simple_message_bswap and simple_message_float64.
-#
-# simple_message - is the default library.  This library should be used
-# when the target for the simple message is the same endian (i.e. both
-# big-endian or little-endian).  Intel based machines are little endian
-#
-# simple_message_bswap - is an alternative library that can be used
-# when the target for simple message is a DIFFERENT endian AND when the target
-# target cannot perform byte swapping (as is the case for some industrial
-# controllers).  This library performs byte swapping at the lowest load/unload
-# levels.
-#
-# simple_message_float64 - another alternative which uses 8 byte floats instead
-# of 4 byte floats (ie: double precision vs single precision).
-# This variant changes the shared_float typedef everywhere to be 8 byte floats.
-#
-# NOTE: The libraries generated this package are not included in the catkin_package
-# macro because libraries must be explicitly linked in projects that depend on this
-# package.  If this is not done (and these libraries were exported), then multiple
-# library definitions (normal - simple_message, byteswapped - simple_message_bswap
-# and simple_message_float64) are all included (this is bad).
-
-catkin_package(
-    CATKIN_DEPENDS roscpp industrial_msgs
-    INCLUDE_DIRS include
-    LIBRARIES ${PROJECT_NAME}_dummy
-    CFG_EXTRAS
-      issue46_workaround.cmake
-      platform_build_flags.cmake
-)
-
-
-include_directories(include
-  ${catkin_INCLUDE_DIRS}
-)
-
 
 # generate dummy library (we export it in catkin_package(..)), to force catkin
 # to set up LIBRARY_DIRS properly.
@@ -89,6 +87,59 @@ add_custom_command(
   OUTPUT  ${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}_dummy.cpp
   COMMAND ${CMAKE_COMMAND} -E touch ${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}_dummy.cpp)
 add_library(${PROJECT_NAME}_dummy ${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}_dummy.cpp)
+
+
+# DEFAULT LIBRARY (SAME ENDIAN)
+add_library(${PROJECT_NAME} ${SRC_FILES})
+# NOTE: keep these in-sync with the lists in 'cmake/platform_build_flags.cmake'.
+# Yes, we could have used get_target_property(..) and then configure_file(..)
+# (or Catkin's equivalent), but there is a low probably these will ever change
+# again, so for now, manually managing it all is an OK trade-off
+target_compile_definitions(${PROJECT_NAME} PUBLIC
+  SIMPLE_MESSAGE_USE_ROS SIMPLE_MESSAGE_LINUX)
+target_link_libraries(${PROJECT_NAME} ${catkin_LIBRARIES})
+target_link_libraries(${PROJECT_NAME} $<$<BOOL:${WIN32}>:Ws2_32.lib>)
+add_dependencies(${PROJECT_NAME} ${industrial_msgs_EXPORTED_TARGETS})
+
+# ALTERNATIVE LIBRARY (DIFFERENT ENDIAN)
+add_library(${PROJECT_NAME}_bswap ${SRC_FILES})
+# NOTE: keep these in-sync with the lists in 'cmake/platform_build_flags.cmake'
+target_compile_definitions(${PROJECT_NAME}_bswap PUBLIC
+  SIMPLE_MESSAGE_USE_ROS SIMPLE_MESSAGE_LINUX BYTE_SWAPPING)
+target_link_libraries(${PROJECT_NAME}_bswap ${catkin_LIBRARIES})
+target_link_libraries(${PROJECT_NAME}_bswap $<$<BOOL:${WIN32}>:Ws2_32.lib>)
+add_dependencies(${PROJECT_NAME}_bswap ${industrial_msgs_EXPORTED_TARGETS})
+
+# ALTERNATIVE LIBRARY (64-bit floats)
+add_library(${PROJECT_NAME}_float64 ${SRC_FILES})
+# NOTE: keep these in-sync with the lists in 'cmake/platform_build_flags.cmake'
+target_compile_definitions(${PROJECT_NAME}_float64 PUBLIC
+  SIMPLE_MESSAGE_USE_ROS SIMPLE_MESSAGE_LINUX FLOAT64)
+target_link_libraries(${PROJECT_NAME}_float64 ${catkin_LIBRARIES})
+target_link_libraries(${PROJECT_NAME}_float64 $<$<BOOL:${WIN32}>:Ws2_32.lib>)
+add_dependencies(${PROJECT_NAME}_float64 ${industrial_msgs_EXPORTED_TARGETS})
+
+
+# NOTE: All test files require TEST_PORT_BASE to be defined.  Defining different
+# ports for each test executable allows them to run in parallel.
+if(CATKIN_ENABLE_TESTING)
+    catkin_add_gtest(utest ${UTEST_SRC_FILES})
+    target_compile_definitions(utest PRIVATE TEST_PORT_BASE=11000)
+    target_link_libraries(utest ${PROJECT_NAME})
+
+    catkin_add_gtest(utest_byte_swapping ${UTEST_SRC_FILES})
+    target_compile_definitions(utest_byte_swapping PRIVATE TEST_PORT_BASE=12000)
+    target_link_libraries(utest_byte_swapping ${PROJECT_NAME}_bswap)
+
+    catkin_add_gtest(utest_float64 ${UTEST_SRC_FILES})
+    target_compile_definitions(utest_float64 PRIVATE TEST_PORT_BASE=13000 FLOAT64)
+    target_link_libraries(utest_float64 ${PROJECT_NAME}_float64)
+
+    catkin_add_gtest(utest_udp ${UTEST_SRC_FILES})
+    target_compile_definitions(utest_udp PRIVATE TEST_PORT_BASE=15000 UDP_TEST)
+    target_link_libraries(utest_udp ${PROJECT_NAME})
+endif()
+
 # unfortunately this will have to be installed, but the linker will remove it
 # from the library dependencies of dependent targets, as it contains no symbols
 # that can be imported from it.
@@ -96,63 +147,9 @@ install(TARGETS ${PROJECT_NAME}_dummy
   ARCHIVE DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
   LIBRARY DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
   RUNTIME DESTINATION ${CATKIN_GLOBAL_BIN_DESTINATION})
-
-
-# NOTE: All test files require TEST_PORT_BASE to be defined.  Defining different
-# ports for each test executable allows them to run in parallel.
-
-# DEFAULT LIBRARY (SAME ENDIAN)
-add_library(simple_message ${SRC_FILES})
-# NOTE: keep these in-sync with the lists in 'cmake/platform_build_flags.cmake'.
-# Yes, we could have used get_target_property(..) and then configure_file(..)
-# (or Catkin's equivalent), but there is a low probably these will ever change
-# again, so for now, manually managing it all is an OK trade-off
-target_compile_definitions(simple_message PUBLIC
-  SIMPLE_MESSAGE_USE_ROS SIMPLE_MESSAGE_LINUX)
-target_link_libraries(simple_message ${catkin_LIBRARIES})
-target_link_libraries(simple_message $<$<BOOL:${WIN32}>:Ws2_32.lib>)
-add_dependencies(simple_message ${industrial_msgs_EXPORTED_TARGETS})
-
-# ALTERNATIVE LIBRARY (DIFFERENT ENDIAN)
-add_library(simple_message_bswap ${SRC_FILES})
-# NOTE: keep these in-sync with the lists in 'cmake/platform_build_flags.cmake'
-target_compile_definitions(simple_message_bswap PUBLIC
-  SIMPLE_MESSAGE_USE_ROS SIMPLE_MESSAGE_LINUX BYTE_SWAPPING)
-target_link_libraries(simple_message_bswap ${catkin_LIBRARIES})
-target_link_libraries(simple_message_bswap $<$<BOOL:${WIN32}>:Ws2_32.lib>)
-add_dependencies(simple_message_bswap ${industrial_msgs_EXPORTED_TARGETS})
-
-# ALTERNATIVE LIBRARY (64-bit floats)
-add_library(simple_message_float64 ${SRC_FILES})
-# NOTE: keep these in-sync with the lists in 'cmake/platform_build_flags.cmake'
-target_compile_definitions(simple_message_float64 PUBLIC
-  SIMPLE_MESSAGE_USE_ROS SIMPLE_MESSAGE_LINUX FLOAT64)
-target_link_libraries(simple_message_float64 ${catkin_LIBRARIES})
-target_link_libraries(simple_message_float64 $<$<BOOL:${WIN32}>:Ws2_32.lib>)
-add_dependencies(simple_message_float64 ${industrial_msgs_EXPORTED_TARGETS})
-
-if(CATKIN_ENABLE_TESTING)
-
-    catkin_add_gtest(utest ${UTEST_SRC_FILES})
-    target_compile_definitions(utest PRIVATE TEST_PORT_BASE=11000)
-    target_link_libraries(utest simple_message)
-
-    catkin_add_gtest(utest_byte_swapping ${UTEST_SRC_FILES})
-    target_compile_definitions(utest_byte_swapping PRIVATE TEST_PORT_BASE=12000)
-    target_link_libraries(utest_byte_swapping simple_message_bswap)
-
-    catkin_add_gtest(utest_float64 ${UTEST_SRC_FILES})
-    target_compile_definitions(utest_float64 PRIVATE TEST_PORT_BASE=13000 FLOAT64)
-    target_link_libraries(utest_float64 simple_message_float64)
-
-    catkin_add_gtest(utest_udp ${UTEST_SRC_FILES})
-    target_compile_definitions(utest_udp PRIVATE TEST_PORT_BASE=15000 UDP_TEST)
-    target_link_libraries(utest_udp simple_message)
-
-endif()
-
+        
 install(
-    TARGETS simple_message simple_message_bswap simple_message_float64 
+    TARGETS ${PROJECT_NAME} ${PROJECT_NAME}_bswap ${PROJECT_NAME}_float64 
     ARCHIVE DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
     LIBRARY DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
     RUNTIME DESTINATION ${CATKIN_GLOBAL_BIN_DESTINATION})
@@ -160,4 +157,3 @@ install(
 install(
     DIRECTORY include/${PROJECT_NAME}/
     DESTINATION ${CATKIN_PACKAGE_INCLUDE_DESTINATION})
-


### PR DESCRIPTION
As per subject.

Rebased -- and slightly extended -- version of #233, which addresses #194.

It's not perfect yet, as there's one unresolved complaint about a missing `exec_depend` on `rviz` (but see https://github.com/fkie/catkin_lint/issues/98).

Attribution and provenance of the original commit retained.
