### PR TITLE
Rebased 246: receive timeouts for simple socket

### DIFF
--- a/simple_message/include/simple_message/smpl_msg_connection.h
+++ b/simple_message/include/simple_message/smpl_msg_connection.h
@@ -87,12 +87,12 @@ public:
    * \brief Receives a message using the data connection with a timeout.
    *
    * \param [out] message Populated with received message
-   * \param [in] timeoutMs The timeout for receiving a message, in milliseconds
+   * \param [in] timeout_ms The timeout for receiving a message, in milliseconds
    *
    * \return true if successful
    */
   virtual bool receiveMsg(industrial::simple_message::SimpleMessage & message,
-                          industrial::shared_types::shared_int timeoutMs);
+                          industrial::shared_types::shared_int timeout_ms);
 
   /**
    * \brief Performs a complete send and receive.  This is helpful when sending
@@ -114,14 +114,14 @@ public:
    *
    * \param [in] send The message to send
    * \param [out] recv Populated with received message
-   * \param [in] timeoutMs The timeout for receiving a message, in milliseconds
+   * \param [in] timeout_ms The timeout for receiving a message, in milliseconds
    * \param [in] verbose Turn on low level logging
    *
    * \return true if successful
    */
   bool sendAndReceiveMsg(industrial::simple_message::SimpleMessage & send,
                          industrial::simple_message::SimpleMessage & recv,
-                         industrial::shared_types::shared_int timeoutMs,
+                         industrial::shared_types::shared_int timeout_ms,
                          bool verbose = false);
 
   /**
@@ -157,14 +157,14 @@ private:
    *
    * \param data to receive.
    * \param size (in bytes) of data to receive
-   * \param timeoutMs Timeout to receive a message (in milliseconds). A negative timeout
+   * \param timeout_ms Timeout to receive a message (in milliseconds). A negative timeout
    * means that this function should wait indefinitely.
    *
    * \return true if successful
    */
   virtual bool receiveBytes(industrial::byte_array::ByteArray & buffer,
                             industrial::shared_types::shared_int num_bytes,
-                            industrial::shared_types::shared_int timeoutMs) = 0;
+                            industrial::shared_types::shared_int timeout_ms) = 0;
 };
 
 } //namespace message_connection

--- a/simple_message/include/simple_message/smpl_msg_connection.h
+++ b/simple_message/include/simple_message/smpl_msg_connection.h
@@ -64,7 +64,7 @@ class SmplMsgConnection
 public:
 
   // Message
-  
+
   /**
    * \brief Sends a message using the data connection
    *
@@ -73,7 +73,7 @@ public:
    * \return true if successful
    */
   virtual bool sendMsg(industrial::simple_message::SimpleMessage & message);
-  
+
   /**
    * \brief Receives a message using the data connection
    *
@@ -82,7 +82,18 @@ public:
    * \return true if successful
    */
   virtual bool receiveMsg(industrial::simple_message::SimpleMessage & message);
-  
+
+  /**
+   * \brief Receives a message using the data connection with a timeout.
+   *
+   * \param [out] message Populated with received message
+   * \param [in] timeoutMs The timeout for receiving a message, in milliseconds
+   *
+   * \return true if successful
+   */
+  virtual bool receiveMsg(industrial::simple_message::SimpleMessage & message,
+                          industrial::shared_types::shared_int timeoutMs);
+
   /**
    * \brief Performs a complete send and receive.  This is helpful when sending
    * a message that requires and explicit reply
@@ -94,7 +105,23 @@ public:
    * \return true if successful
    */
   bool sendAndReceiveMsg(industrial::simple_message::SimpleMessage & send,
-                         industrial::simple_message::SimpleMessage & recv, 
+                         industrial::simple_message::SimpleMessage & recv,
+                         bool verbose = false);
+
+  /**
+   * \brief Performs a complete send and receive with a timeout.
+   * This is helpful when sending a message that requires and explicit reply.
+   *
+   * \param [in] send The message to send
+   * \param [out] recv Populated with received message
+   * \param [in] timeoutMs The timeout for receiving a message, in milliseconds
+   * \param [in] verbose Turn on low level logging
+   *
+   * \return true if successful
+   */
+  bool sendAndReceiveMsg(industrial::simple_message::SimpleMessage & send,
+                         industrial::simple_message::SimpleMessage & recv,
+                         industrial::shared_types::shared_int timeoutMs,
                          bool verbose = false);
 
   /**
@@ -123,19 +150,21 @@ private:
    * \return true if successful
    */
   virtual bool sendBytes(industrial::byte_array::ByteArray & buffer) =0;
-  
+
   /**
-   * \brief Method used by receive message interface method.  This should be overridden 
-   * for the specific connection type
+   * \brief Method used by receive message interface method.  This should be overridden
+   * for the specific connection type.
    *
    * \param data to receive.
-   * \param size (in bytes) of data to receive 
+   * \param size (in bytes) of data to receive
+   * \param timeoutMs Timeout to receive a message (in milliseconds). A negative timeout
+   * means that this function should wait indefinitely.
    *
    * \return true if successful
    */
   virtual bool receiveBytes(industrial::byte_array::ByteArray & buffer,
-                            industrial::shared_types::shared_int num_bytes) =0;
-
+                            industrial::shared_types::shared_int num_bytes,
+                            industrial::shared_types::shared_int timeoutMs) = 0;
 };
 
 } //namespace message_connection

--- a/simple_message/include/simple_message/socket/simple_socket.h
+++ b/simple_message/include/simple_message/socket/simple_socket.h
@@ -265,12 +265,14 @@ protected:
   {
     LOG_ERROR("%s, rc: %d. Error: '%s' (errno: %d)", msg, rc, strerror(error_no), error_no);
   }
-  
+
   // Send/Receive functions (inherited classes should override raw methods
   // Virtual
   bool sendBytes(industrial::byte_array::ByteArray & buffer);
   bool receiveBytes(industrial::byte_array::ByteArray & buffer,
-      industrial::shared_types::shared_int num_bytes);
+      industrial::shared_types::shared_int num_bytes,
+      industrial::shared_types::shared_int timeoutMs);
+
   // Virtual
   virtual int rawSendBytes(char *buffer,
       industrial::shared_types::shared_int num_bytes)=0;

--- a/simple_message/include/simple_message/socket/simple_socket.h
+++ b/simple_message/include/simple_message/socket/simple_socket.h
@@ -271,7 +271,7 @@ protected:
   bool sendBytes(industrial::byte_array::ByteArray & buffer);
   bool receiveBytes(industrial::byte_array::ByteArray & buffer,
       industrial::shared_types::shared_int num_bytes,
-      industrial::shared_types::shared_int timeoutMs);
+      industrial::shared_types::shared_int timeout_ms);
 
   // Virtual
   virtual int rawSendBytes(char *buffer,

--- a/simple_message/include/simple_message/socket/simple_socket.h
+++ b/simple_message/include/simple_message/socket/simple_socket.h
@@ -222,7 +222,7 @@ protected:
   /**
    * \brief socket ready polling timeout (ms)
    */
-  static const int SOCKET_POLL_TO = 1000;
+  static const int SOCKET_POLL_TO = 10;
 
   /**
    * \brief internal data buffer for receiving

--- a/simple_message/src/smpl_msg_connection.cpp
+++ b/simple_message/src/smpl_msg_connection.cpp
@@ -44,6 +44,7 @@
 #endif
 
 using namespace industrial::simple_message;
+using namespace industrial::shared_types;
 using namespace industrial::byte_array;
 
 namespace industrial
@@ -78,6 +79,12 @@ return rtn;
 
 bool SmplMsgConnection::receiveMsg(SimpleMessage & message)
 {
+  return receiveMsg(message, -1);
+}
+
+
+bool SmplMsgConnection::receiveMsg(SimpleMessage & message, shared_int timeoutMs)
+{
   ByteArray lengthBuffer;
   ByteArray msgBuffer;
   int length;
@@ -85,7 +92,7 @@ bool SmplMsgConnection::receiveMsg(SimpleMessage & message)
   bool rtn = false;
 
 
-  rtn = this->receiveBytes(lengthBuffer, message.getLengthSize());
+  rtn = this->receiveBytes(lengthBuffer, message.getLengthSize(), timeoutMs);
 
   if (rtn)
   {
@@ -94,7 +101,7 @@ bool SmplMsgConnection::receiveMsg(SimpleMessage & message)
 
     if (rtn)
     {
-      rtn = this->receiveBytes(msgBuffer, length);
+      rtn = this->receiveBytes(msgBuffer, length, timeoutMs);
 
       if (rtn)
       {
@@ -123,9 +130,14 @@ bool SmplMsgConnection::receiveMsg(SimpleMessage & message)
 }
 
 
-
 bool SmplMsgConnection::sendAndReceiveMsg(SimpleMessage & send, SimpleMessage & recv, bool verbose)
-{	
+{
+  return sendAndReceiveMsg(send, recv, -1, verbose);
+}
+
+bool SmplMsgConnection::sendAndReceiveMsg(SimpleMessage & send, SimpleMessage & recv,
+                                          shared_int timeoutMs, bool verbose)
+{
   bool rtn = false;
   rtn = this->sendMsg(send);
   if (rtn)
@@ -133,7 +145,7 @@ bool SmplMsgConnection::sendAndReceiveMsg(SimpleMessage & send, SimpleMessage & 
     if(verbose) {
       LOG_ERROR("Sent message");
     }
-    rtn = this->receiveMsg(recv);
+    rtn = this->receiveMsg(recv, timeoutMs);
     if(verbose) {
       LOG_ERROR("Got message");
     }

--- a/simple_message/src/smpl_msg_connection.cpp
+++ b/simple_message/src/smpl_msg_connection.cpp
@@ -83,7 +83,7 @@ bool SmplMsgConnection::receiveMsg(SimpleMessage & message)
 }
 
 
-bool SmplMsgConnection::receiveMsg(SimpleMessage & message, shared_int timeoutMs)
+bool SmplMsgConnection::receiveMsg(SimpleMessage & message, shared_int timeout_ms)
 {
   ByteArray lengthBuffer;
   ByteArray msgBuffer;
@@ -92,7 +92,7 @@ bool SmplMsgConnection::receiveMsg(SimpleMessage & message, shared_int timeoutMs
   bool rtn = false;
 
 
-  rtn = this->receiveBytes(lengthBuffer, message.getLengthSize(), timeoutMs);
+  rtn = this->receiveBytes(lengthBuffer, message.getLengthSize(), timeout_ms);
 
   if (rtn)
   {
@@ -101,7 +101,7 @@ bool SmplMsgConnection::receiveMsg(SimpleMessage & message, shared_int timeoutMs
 
     if (rtn)
     {
-      rtn = this->receiveBytes(msgBuffer, length, timeoutMs);
+      rtn = this->receiveBytes(msgBuffer, length, timeout_ms);
 
       if (rtn)
       {
@@ -136,7 +136,7 @@ bool SmplMsgConnection::sendAndReceiveMsg(SimpleMessage & send, SimpleMessage & 
 }
 
 bool SmplMsgConnection::sendAndReceiveMsg(SimpleMessage & send, SimpleMessage & recv,
-                                          shared_int timeoutMs, bool verbose)
+                                          shared_int timeout_ms, bool verbose)
 {
   bool rtn = false;
   rtn = this->sendMsg(send);
@@ -145,7 +145,7 @@ bool SmplMsgConnection::sendAndReceiveMsg(SimpleMessage & send, SimpleMessage & 
     if(verbose) {
       LOG_ERROR("Sent message");
     }
-    rtn = this->receiveMsg(recv, timeoutMs);
+    rtn = this->receiveMsg(recv, timeout_ms);
     if(verbose) {
       LOG_ERROR("Got message");
     }

--- a/simple_message/src/socket/simple_socket.cpp
+++ b/simple_message/src/socket/simple_socket.cpp
@@ -95,11 +95,12 @@ namespace industrial
 
     }
 
-    bool SimpleSocket::receiveBytes(ByteArray & buffer, shared_int num_bytes)
+    bool SimpleSocket::receiveBytes(ByteArray & buffer, shared_int num_bytes, shared_int timeoutMs)
     {
       int rc = this->SOCKET_FAIL;
       bool rtn = false;
       shared_int remainBytes = num_bytes;
+      shared_int remainTimeMs = timeoutMs;
       bool ready, error;
 
       // Reset the buffer (this is not required since the buffer length should
@@ -118,7 +119,7 @@ namespace industrial
       if (this->isConnected())
       {
         buffer.init();
-        while (remainBytes > 0)
+        while (remainBytes > 0 && (timeoutMs < 0 || remainTimeMs > 0))
         {
           // Polling the socket results in an "interruptable" socket read.  This
           // allows Control-C to break out of a socket read.  Without polling,
@@ -131,24 +132,27 @@ namespace industrial
               if (this->SOCKET_FAIL == rc)
               {
                 this->logSocketError("Socket received failed", rc, errno);
-		        remainBytes = 0;
+                remainBytes = 0;
                 rtn = false;
                 break;
               }
               else if (0 == rc)
               {
                 LOG_WARN("Recieved zero bytes: %u", rc);
-		        remainBytes = 0;
+                remainBytes = 0;
                 rtn = false;
                 break;
               }
               else
               {
                 remainBytes = remainBytes - rc;
+                remainTimeMs = timeoutMs;  // Reset the timeout on successful read
                 LOG_COMM("Byte array receive, bytes read: %u, bytes reqd: %u, bytes left: %u",
                     rc, num_bytes, remainBytes);
                 buffer.load(&this->buffer_, rc);
-                rtn = true;
+                if (remainBytes <= 0) {
+                  rtn = true;
+                }
               }
             }
             else if(error)
@@ -166,17 +170,19 @@ namespace industrial
           }
           else
           {
+            remainTimeMs = remainTimeMs - this->SOCKET_POLL_TO;
             LOG_COMM("Socket poll timeout, trying again");
           }
         }
       }
       else
       {
-        LOG_WARN("Not connected, bytes not sent");
+        LOG_WARN("Not connected, bytes not received");
         rtn = false;
       }
 
-      if (!rtn)
+      // Close the socket on all failures except timeouts
+      if (!rtn && (timeoutMs < 0 || remainTimeMs > 0))
       {
         this->setConnected(false);
       }
@@ -185,4 +191,3 @@ namespace industrial
 
   }  //simple_socket
 }  //industrial
-

--- a/simple_message/src/socket/simple_socket.cpp
+++ b/simple_message/src/socket/simple_socket.cpp
@@ -95,12 +95,12 @@ namespace industrial
 
     }
 
-    bool SimpleSocket::receiveBytes(ByteArray & buffer, shared_int num_bytes, shared_int timeoutMs)
+    bool SimpleSocket::receiveBytes(ByteArray & buffer, shared_int num_bytes, shared_int timeout_ms)
     {
       int rc = this->SOCKET_FAIL;
       bool rtn = false;
       shared_int remainBytes = num_bytes;
-      shared_int remainTimeMs = timeoutMs;
+      shared_int remainTimeMs = timeout_ms;
       bool ready, error;
 
       // Reset the buffer (this is not required since the buffer length should
@@ -119,7 +119,7 @@ namespace industrial
       if (this->isConnected())
       {
         buffer.init();
-        while (remainBytes > 0 && (timeoutMs < 0 || remainTimeMs > 0))
+        while (remainBytes > 0 && (timeout_ms < 0 || remainTimeMs > 0))
         {
           // Polling the socket results in an "interruptable" socket read.  This
           // allows Control-C to break out of a socket read.  Without polling,
@@ -146,7 +146,7 @@ namespace industrial
               else
               {
                 remainBytes = remainBytes - rc;
-                remainTimeMs = timeoutMs;  // Reset the timeout on successful read
+                remainTimeMs = timeout_ms;  // Reset the timeout on successful read
                 LOG_COMM("Byte array receive, bytes read: %u, bytes reqd: %u, bytes left: %u",
                     rc, num_bytes, remainBytes);
                 buffer.load(&this->buffer_, rc);
@@ -182,7 +182,7 @@ namespace industrial
       }
 
       // Close the socket on all failures except timeouts
-      if (!rtn && (timeoutMs < 0 || remainTimeMs > 0))
+      if (!rtn && (timeout_ms < 0 || remainTimeMs > 0))
       {
         this->setConnected(false);
       }

--- a/simple_message/test/utest.cpp
+++ b/simple_message/test/utest.cpp
@@ -263,7 +263,12 @@ class TestServer : public TcpServer
   public:
   bool receiveBytes(ByteArray & buffer, shared_int num_bytes)
   {
-    return TcpServer::receiveBytes(buffer, num_bytes);
+    return TcpServer::receiveBytes(buffer, num_bytes, -1);
+  }
+
+  bool receiveBytes(ByteArray & buffer, shared_int num_bytes, shared_int timeoutMs)
+  {
+    return TcpServer::receiveBytes(buffer, num_bytes, timeoutMs);
   }
 };
 #else
@@ -280,7 +285,12 @@ class TestServer : public UdpServer
   public:
   bool receiveBytes(ByteArray & buffer, shared_int num_bytes)
   {
-    return UdpServer::receiveBytes(buffer, num_bytes);
+    return UdpServer::receiveBytes(buffer, num_bytes, -1);
+  }
+
+  bool receiveBytes(ByteArray & buffer, shared_int num_bytes, shared_int timeoutMs)
+  {
+    return UdpServer::receiveBytes(buffer, num_bytes, timeoutMs);
   }
 };
 #endif
@@ -288,7 +298,7 @@ class TestServer : public UdpServer
 void*
 connectServerFunc(void* arg)
 {
-  TestServer* server = (TestServer*)arg;  
+  TestServer* server = (TestServer*)arg;
   server->makeConnect();
   return NULL;
 }
@@ -335,12 +345,48 @@ TEST(SocketSuite, read)
   ASSERT_EQ(ONE_INTS, recv.getBufferSize());
 }
 
+TEST(SocketSuite, readTimeout)
+{
+  const int port = TEST_PORT_BASE;
+  char ipAddr[] = "127.0.0.1";
+
+  TestClient client;
+  TestServer server;
+  ByteArray send, recv;
+  shared_int DATA = 99;
+  shared_int TWO_INTS = 2 * sizeof(shared_int);
+  shared_int ONE_INTS = 1 * sizeof(shared_int);
+  shared_int TIMEOUT_MS = 100;
+
+  // Construct server
+  ASSERT_TRUE(server.init(port));
+
+  // Construct a client
+  ASSERT_TRUE(client.init(&ipAddr[0], port));
+  pthread_t serverConnectThrd;
+  pthread_create(&serverConnectThrd, NULL, connectServerFunc, &server);
+
+  ASSERT_TRUE(client.makeConnect());
+  pthread_join(serverConnectThrd, NULL);
+
+  ASSERT_TRUE(send.load(DATA));
+
+  // Try a read without sending anything
+  ASSERT_FALSE(server.receiveBytes(recv, TWO_INTS, TIMEOUT_MS));
+  ASSERT_EQ(0, recv.getBufferSize());
+
+  // Send too few bytes
+  ASSERT_TRUE(client.sendBytes(send));
+  sleep(2);
+  ASSERT_FALSE(server.receiveBytes(recv, TWO_INTS, TIMEOUT_MS));
+  ASSERT_EQ(ONE_INTS, recv.getBufferSize());
+}
 
 // Utility for running tcp client in sending loop
 void
 spinSender(void* arg, bool &running)
 {
-  TestClient* client = (TestClient*)arg;  
+  TestClient* client = (TestClient*)arg;
   ByteArray send;
   const int DATA = 256;
 
@@ -558,4 +604,3 @@ int main(int argc, char **argv)
   testing::InitGoogleTest(&argc, argv);
   return RUN_ALL_TESTS();
 }
-

--- a/simple_message/test/utest.cpp
+++ b/simple_message/test/utest.cpp
@@ -266,9 +266,9 @@ class TestServer : public TcpServer
     return TcpServer::receiveBytes(buffer, num_bytes, -1);
   }
 
-  bool receiveBytes(ByteArray & buffer, shared_int num_bytes, shared_int timeoutMs)
+  bool receiveBytes(ByteArray & buffer, shared_int num_bytes, shared_int timeout_ms)
   {
-    return TcpServer::receiveBytes(buffer, num_bytes, timeoutMs);
+    return TcpServer::receiveBytes(buffer, num_bytes, timeout_ms);
   }
 };
 #else
@@ -288,9 +288,9 @@ class TestServer : public UdpServer
     return UdpServer::receiveBytes(buffer, num_bytes, -1);
   }
 
-  bool receiveBytes(ByteArray & buffer, shared_int num_bytes, shared_int timeoutMs)
+  bool receiveBytes(ByteArray & buffer, shared_int num_bytes, shared_int timeout_ms)
   {
-    return UdpServer::receiveBytes(buffer, num_bytes, timeoutMs);
+    return UdpServer::receiveBytes(buffer, num_bytes, timeout_ms);
   }
 };
 #endif


### PR DESCRIPTION
As per subject.

Commit provenance and attribution retained, although the original account appears to have been deleted.

One additional commit fixes some style issues.
