### PR TITLE
ci: use catkin_tools for focal builds

### DIFF
--- a/.github/workflows/ci_focal.yml
+++ b/.github/workflows/ci_focal.yml
@@ -20,6 +20,7 @@ jobs:
         ros_repo: [ main, testing ]
 
     env:
+      BUILDER: catkin_tools
       CCACHE_DIR: "${{ github.workspace }}/.ccache"
 
     steps:


### PR DESCRIPTION
As per subject.

Colcon seems to have trouble discovering all the tests.
