### PR TITLE
Enable catkin_lint

### DIFF
--- a/.github/workflows/ci_bionic.yml
+++ b/.github/workflows/ci_bionic.yml
@@ -21,6 +21,7 @@ jobs:
 
     env:
       CCACHE_DIR: "${{ github.workspace }}/.ccache"
+      CATKIN_LINT: pedantic
 
     steps:
       - name: Fetch repository

--- a/.github/workflows/ci_focal.yml
+++ b/.github/workflows/ci_focal.yml
@@ -22,6 +22,7 @@ jobs:
     env:
       BUILDER: catkin_tools
       CCACHE_DIR: "${{ github.workspace }}/.ccache"
+      CATKIN_LINT: pedantic
 
     steps:
       - name: Fetch repository

--- a/industrial_robot_client/launch/robot_state_visualize.launch
+++ b/industrial_robot_client/launch/robot_state_visualize.launch
@@ -25,5 +25,6 @@
 	<node name="state_publisher" pkg="robot_state_publisher" type="state_publisher"/>
 	<node name="robot_state" pkg="industrial_robot_client" type="robot_state"/>
 
+	<!-- catkin_lint: ignore_once launch_depend -->
 	<node name="rviz" pkg="rviz" type="rviz" args="-d $(find industrial_robot_client)/config/robot_state_visualize.rviz"/>
 </launch>


### PR DESCRIPTION
As per subject.

The `ignore_once` pragma in the `.launch` file requires an unreleased version of `catkin_lint` for now (fkie/catkin_lint#98), so this PR will fail CI.

We'll wait until the updated version is released.
