### PR TITLE
Sort-of rebase of 83: traj action aborts on error

### DIFF
--- a/industrial_robot_client/include/industrial_robot_client/joint_trajectory_action.h
+++ b/industrial_robot_client/include/industrial_robot_client/joint_trajectory_action.h
@@ -188,7 +188,7 @@ private:
    * cannot accurately report controller status (ie: have UNKNOWNs in
    * the RobotStatus messages they publish).
    */
-  bool ignore_motion_server_error_;
+  bool ignore_motion_server_error_ = false;
 
   /**
    * \brief Should the action server consider UNKNOWN for TriStates in
@@ -201,7 +201,7 @@ private:
    * are unable to accurately report controller status, by allowing
    * the action server to assume UNKNOWN == OK.
    */
-  bool consider_status_unknowns_ok_;
+  bool consider_status_unknowns_ok_ = false;
 
   /**
    * \brief Watch dog callback, used to detect robot driver failures

--- a/industrial_robot_client/include/industrial_robot_client/joint_trajectory_action.h
+++ b/industrial_robot_client/include/industrial_robot_client/joint_trajectory_action.h
@@ -246,6 +246,11 @@ private:
   void robotStatusCB(const industrial_msgs::RobotStatusConstPtr &msg);
 
   /**
+   * \brief Sends a stop command (empty message) to the robot driver.
+   */
+  void stopRelay();
+
+  /**
    * \brief Aborts the current action goal and sends a stop command
    * (empty message) to the robot driver.
    *

--- a/industrial_robot_client/include/industrial_robot_client/joint_trajectory_action.h
+++ b/industrial_robot_client/include/industrial_robot_client/joint_trajectory_action.h
@@ -182,7 +182,8 @@ private:
    *
    * This is a backwards compatibility 'tunable knob'.
    *
-   * Set this to true to keep the old behaviour.
+   * The constructor overrides the default here with the value of the private
+   * parameter on the parameter server with the same name.
    *
    * This is configurable, as it's possible drivers for certain robots
    * cannot accurately report controller status (ie: have UNKNOWNs in
@@ -195,6 +196,9 @@ private:
    * a RobotStatus message as OK?
    *
    * This is a backwards compatibility 'tunable knob'.
+   *
+   * The constructor overrides the default here with the value of the private
+   * parameter on the parameter server with the same name.
    *
    * Use this to effectively ignore UNKNOWN states for TriStates in
    * RobotStatus messages. This can help with OEM server programs which

--- a/industrial_robot_client/include/industrial_robot_client/joint_trajectory_action.h
+++ b/industrial_robot_client/include/industrial_robot_client/joint_trajectory_action.h
@@ -177,6 +177,33 @@ private:
   static const double WATCHDOG_PERIOD_;// = 1.0;
 
   /**
+   * \brief Should the action server abort goals if the OEM server
+   * program reports a problem?
+   *
+   * This is a backwards compatibility 'tunable knob'.
+   *
+   * Set this to true to keep the old behaviour.
+   *
+   * This is configurable, as it's possible drivers for certain robots
+   * cannot accurately report controller status (ie: have UNKNOWNs in
+   * the RobotStatus messages they publish).
+   */
+  bool ignore_motion_server_error_;
+
+  /**
+   * \brief Should the action server consider UNKNOWN for TriStates in
+   * a RobotStatus message as OK?
+   *
+   * This is a backwards compatibility 'tunable knob'.
+   *
+   * Use this to effectively ignore UNKNOWN states for TriStates in
+   * RobotStatus messages. This can help with OEM server programs which
+   * are unable to accurately report controller status, by allowing
+   * the action server to assume UNKNOWN == OK.
+   */
+  bool consider_status_unknowns_ok_;
+
+  /**
    * \brief Watch dog callback, used to detect robot driver failures
    *
    * \param e time event information

--- a/industrial_robot_client/include/industrial_robot_client/utils.h
+++ b/industrial_robot_client/include/industrial_robot_client/utils.h
@@ -36,7 +36,7 @@
 #include <string>
 #include <map>
 
-#include <industrial_msgs/RobotStatus.h>
+#include <industrial_msgs/TriState.h>
 
 
 namespace industrial_robot_client

--- a/industrial_robot_client/include/industrial_robot_client/utils.h
+++ b/industrial_robot_client/include/industrial_robot_client/utils.h
@@ -126,7 +126,7 @@ bool isWithinRange(const std::vector<std::string> & lhs_keys, const std::vector<
  *
  * \return true if the state is UNKNOWN
  */
-bool is_unknown(industrial_msgs::TriState const& state)
+bool isUnknown(industrial_msgs::TriState const& state)
 {
   return state.val == industrial_msgs::TriState::UNKNOWN;
 }
@@ -139,10 +139,10 @@ bool is_unknown(industrial_msgs::TriState const& state)
  *
  * \return true if the state is ON
  */
-bool is_on(industrial_msgs::TriState const& state, bool unknown_is_on)
+bool isOn(industrial_msgs::TriState const& state, bool unknown_is_on)
 {
   return state.val == industrial_msgs::TriState::ON
-    || (unknown_is_on && is_unknown(state));
+    || (unknown_is_on && isUnknown(state));
 }
 
 /**
@@ -153,10 +153,10 @@ bool is_on(industrial_msgs::TriState const& state, bool unknown_is_on)
  *
  * \return true if the state is OFF
  */
-bool is_off(industrial_msgs::TriState const& state, bool unknown_is_off)
+bool isOff(industrial_msgs::TriState const& state, bool unknown_is_off)
 {
   return state.val == industrial_msgs::TriState::OFF
-    || (unknown_is_off && is_unknown(state));
+    || (unknown_is_off && isUnknown(state));
 }
 
 } //utils

--- a/industrial_robot_client/include/industrial_robot_client/utils.h
+++ b/industrial_robot_client/include/industrial_robot_client/utils.h
@@ -119,6 +119,9 @@ bool isWithinRange(const std::vector<std::string> & lhs_keys, const std::vector<
                    const std::vector<std::string> & rhs_keys, const std::vector<double> & rhs_values,
                    double full_range);
 
+
+namespace tri_state {
+
 /**
  * \brief Check whether the given TriState is set to UNKNOWN.
  *
@@ -158,6 +161,8 @@ bool isOff(industrial_msgs::TriState const& state, bool unknown_is_off)
   return state.val == industrial_msgs::TriState::OFF
     || (unknown_is_off && isUnknown(state));
 }
+
+} //tri_state
 
 } //utils
 } //industrial_robot_client

--- a/industrial_robot_client/include/industrial_robot_client/utils.h
+++ b/industrial_robot_client/include/industrial_robot_client/utils.h
@@ -36,6 +36,9 @@
 #include <string>
 #include <map>
 
+#include <industrial_msgs/RobotStatus.h>
+
+
 namespace industrial_robot_client
 {
 namespace utils
@@ -115,6 +118,46 @@ bool isWithinRange(const std::vector<std::string> & keys, const std::map<std::st
 bool isWithinRange(const std::vector<std::string> & lhs_keys, const std::vector<double> & lhs_values,
                    const std::vector<std::string> & rhs_keys, const std::vector<double> & rhs_values,
                    double full_range);
+
+/**
+ * \brief Check whether the given TriState is set to UNKNOWN.
+ *
+ * \param[in] state to check
+ *
+ * \return true if the state is UNKNOWN
+ */
+bool is_unknown(industrial_msgs::TriState const& state)
+{
+  return state.val == industrial_msgs::TriState::UNKNOWN;
+}
+
+/**
+ * \brief Check whether the given TriState is set to ON (or HIGH or TRUE ..).
+ *
+ * \param[in] state the state to check
+ * \param[in] unknown_is_on should UNKNOWN be considered ON?
+ *
+ * \return true if the state is ON
+ */
+bool is_on(industrial_msgs::TriState const& state, bool unknown_is_on)
+{
+  return state.val == industrial_msgs::TriState::ON
+    || (unknown_is_on && is_unknown(state));
+}
+
+/**
+ * \brief Check whether the given TriState is set to OFF (or LOW or FALSE ..).
+ *
+ * \param[in] state the state to check
+ * \param[in] unknown_is_off should UNKNOWN be considered OFF?
+ *
+ * \return true if the state is OFF
+ */
+bool is_off(industrial_msgs::TriState const& state, bool unknown_is_off)
+{
+  return state.val == industrial_msgs::TriState::OFF
+    || (unknown_is_off && is_unknown(state));
+}
 
 } //utils
 } //industrial_robot_client

--- a/industrial_robot_client/launch/robot_interface_download.launch
+++ b/industrial_robot_client/launch/robot_interface_download.launch
@@ -30,6 +30,9 @@
   <node pkg="industrial_robot_client" type="motion_download_interface" name="motion_download_interface"/>
   
   <!-- joint_trajectory_action: provides actionlib interface for high-level robot control -->
-  <node pkg="industrial_robot_client" type="joint_trajectory_action" name="joint_trajectory_action"/>
+  <node pkg="industrial_robot_client" type="joint_trajectory_action" name="joint_trajectory_action">
+    <param name="ignore_motion_server_error" type="bool" value="true" />
+    <param name="consider_status_unknowns_ok" type="bool" value="true" />
+  </node>
 
 </launch>

--- a/industrial_robot_client/launch/robot_interface_download.launch
+++ b/industrial_robot_client/launch/robot_interface_download.launch
@@ -18,6 +18,37 @@
   <!-- robot_ip: IP-address of the robot's socket-messaging server -->
   <arg name="robot_ip" doc="IP of the controller" />
   
+  <!-- Prior to https://github.com/ros-industrial/industrial_core/pull/271, the
+       joint_trajectory_action server ignored the state of the OEM server program
+       and essentially open-loop forwarded incoming trajectories to the other
+       nodes in industrial_robot_client.
+
+       The new behaviour is to monitor the OEM server programs and reject
+       incoming goals and abort active ones when needed.
+
+       Set this argument to true to revert back to the old behaviour.
+       If this argument is set to false, the new behaviour will be used.
+  -->
+  <arg name="ignore_motion_server_error" default="false"
+    doc="Should OEM controller state be monitored while accepting goals and during execution?" />
+  
+  <!-- Some OEM server programs (state relays running on the OEM controller)
+       cannot (reliably) determine values for certain fields in RobotStatus
+       messages. Those fields should then be set to TriState::UNKNOWN by those
+       servers.
+
+       UNKNOWN is essentially treated like OFF (or FALSE) by the code which
+       monitors the OEM server program, so for those server programs which must
+       send UNKNOWN, the monitoring code will always detect errors and refuse to
+       execute any trajectories.
+
+       Set this parameter to true to avoid this with such OEM server programs,
+       at the cost of potentially accepting goals and attempting to execute them
+       even if the server program would not be able to actually do that.
+  -->
+  <arg name="consider_status_unknowns_ok" default="false"
+    doc="Should UNKNOWNs in RobotStatus messages be considered as OKs?" />
+  
   <!-- copy the specified IP address to the Parameter Server, for use by nodes below -->
   <param name="/robot_ip_address" type="str" value="$(arg robot_ip)"/>
   
@@ -31,8 +62,8 @@
   
   <!-- joint_trajectory_action: provides actionlib interface for high-level robot control -->
   <node pkg="industrial_robot_client" type="joint_trajectory_action" name="joint_trajectory_action">
-    <param name="ignore_motion_server_error" type="bool" value="true" />
-    <param name="consider_status_unknowns_ok" type="bool" value="true" />
+    <param name="ignore_motion_server_error" type="bool" value="$(arg ignore_motion_server_error)" />
+    <param name="consider_status_unknowns_ok" type="bool" value="$(arg consider_status_unknowns_ok)" />
   </node>
 
 </launch>

--- a/industrial_robot_client/launch/robot_interface_streaming.launch
+++ b/industrial_robot_client/launch/robot_interface_streaming.launch
@@ -30,7 +30,9 @@
   <node pkg="industrial_robot_client" type="motion_streaming_interface" name="motion_streaming_interface"/>
   
   <!-- joint_trajectory_action: provides actionlib interface for high-level robot control -->
-  <node pkg="industrial_robot_client" type="joint_trajectory_action" name="joint_trajectory_action"/>
+  <node pkg="industrial_robot_client" type="joint_trajectory_action" name="joint_trajectory_action">
+    <param name="ignore_motion_server_error" type="bool" value="true" />
+    <param name="consider_status_unknowns_ok" type="bool" value="true" />
+  </node>
 
 </launch>
-

--- a/industrial_robot_client/launch/robot_interface_streaming.launch
+++ b/industrial_robot_client/launch/robot_interface_streaming.launch
@@ -12,15 +12,40 @@
          - joint_trajectory_action : actionlib interface to control robot motion
 
     Usage:
-      robot_interface_streaming.launch robot_ip:=<value>
+      robot_interface_streaming.launch robot_ip:=<value> [other arguments [..]]
   -->
 
   <!-- robot_ip: IP-address of the robot's socket-messaging server -->
   <arg name="robot_ip" doc="IP of controller" />
   
+  <!-- Prior to https://github.com/ros-industrial/industrial_core/pull/271, the
+       joint_trajectory_action server ignored the state of the OEM server program
+       and essentially open-loop forwarded incoming trajectories to the other
+       nodes in industrial_robot_client.
+
+       The new behaviour is to monitor the OEM server programs and reject
+       incoming goals and abort active ones when needed.
+
+       Set this argument to true to revert back to the old behaviour.
+       If this argument is set to false, the new behaviour will be used.
+  -->
   <arg name="ignore_motion_server_error" default="false"
     doc="Should OEM controller state be monitored while accepting goals and during execution?" />
   
+  <!-- Some OEM server programs (state relays running on the OEM controller)
+       cannot (reliably) determine values for certain fields in RobotStatus
+       messages. Those fields should then be set to TriState::UNKNOWN by those
+       servers.
+
+       UNKNOWN is essentially treated like OFF (or FALSE) by the code which
+       monitors the OEM server program, so for those server programs which must
+       send UNKNOWN, the monitoring code will always detect errors and refuse to
+       execute any trajectories.
+
+       Set this parameter to true to avoid this with such OEM server programs,
+       at the cost of potentially accepting goals and attempting to execute them
+       even if the server program would not be able to actually do that.
+  -->
   <arg name="consider_status_unknowns_ok" default="false"
     doc="Should UNKNOWNs in RobotStatus messages be considered as OKs?" />
   

--- a/industrial_robot_client/launch/robot_interface_streaming.launch
+++ b/industrial_robot_client/launch/robot_interface_streaming.launch
@@ -18,6 +18,12 @@
   <!-- robot_ip: IP-address of the robot's socket-messaging server -->
   <arg name="robot_ip" doc="IP of controller" />
   
+  <arg name="ignore_motion_server_error" default="false"
+    doc="Should OEM controller state be monitored while accepting goals and during execution?" />
+  
+  <arg name="consider_status_unknowns_ok" default="false"
+    doc="Should UNKNOWNs in RobotStatus messages be considered as OKs?" />
+  
   <!-- copy the specified IP address to the Parameter Server, for use by nodes below -->
   <param name="/robot_ip_address" type="str" value="$(arg robot_ip)"/>
   
@@ -31,8 +37,8 @@
   
   <!-- joint_trajectory_action: provides actionlib interface for high-level robot control -->
   <node pkg="industrial_robot_client" type="joint_trajectory_action" name="joint_trajectory_action">
-    <param name="ignore_motion_server_error" type="bool" value="true" />
-    <param name="consider_status_unknowns_ok" type="bool" value="true" />
+    <param name="ignore_motion_server_error" type="bool" value="$(arg ignore_motion_server_error)" />
+    <param name="consider_status_unknowns_ok" type="bool" value="$(arg consider_status_unknowns_ok)" />
   </node>
 
 </launch>

--- a/industrial_robot_client/src/joint_trajectory_action.cpp
+++ b/industrial_robot_client/src/joint_trajectory_action.cpp
@@ -54,7 +54,7 @@ JointTrajectoryAction::JointTrajectoryAction() :
 
   // Two parameters for bw-compatibility with the 'old' behaviour.
   // Setting these by default to TRUE, to maintain the previous behaviour
-  pn.param("ignore_motion_server_error", ignore_motion_server_error_, true);
+  pn.param("ignore_motion_server_error", ignore_motion_server_error_, ignore_motion_server_error_);
   pn.param("consider_status_unknowns_ok", consider_status_unknowns_ok_, true);
   std::string log_msg = std::string("Ignoring motion server errors: ") + (ignore_motion_server_error_ ? "true" : "false");
   if (ignore_motion_server_error_)

--- a/industrial_robot_client/src/joint_trajectory_action.cpp
+++ b/industrial_robot_client/src/joint_trajectory_action.cpp
@@ -326,6 +326,7 @@ void JointTrajectoryAction::controllerStateCB(const control_msgs::FollowJointTra
     // would like to use a better error constant, but we have to choose one of the existing
     // constants, and this one comes closest
     result.error_code = control_msgs::FollowJointTrajectoryResult::INVALID_GOAL;
+    result.error_string = abort_msg;
     active_goal_.setAborted(result, abort_msg);
     has_active_goal_ = false;
     ROS_ERROR_STREAM_NAMED(name_, abort_msg);

--- a/industrial_robot_client/src/joint_trajectory_action.cpp
+++ b/industrial_robot_client/src/joint_trajectory_action.cpp
@@ -398,7 +398,7 @@ void JointTrajectoryAction::controllerStateCB(const control_msgs::FollowJointTra
       // the motion state (i.e. old driver), this will still work, but it warns you.
       if (is_off(last_robot_status_->in_motion, /*unknown_is_off=*/false))
       {
-        ROS_INFO_NAMED("joint_trajectory_action.controllerStateCB", "Inside goal constraints - stopped moving-  return success for action");
+        ROS_INFO_NAMED("joint_trajectory_action.controllerStateCB", "Inside goal constraints - stopped moving - return success for action");
         active_goal_.setSucceeded();
         has_active_goal_ = false;
       }

--- a/industrial_robot_client/src/joint_trajectory_action.cpp
+++ b/industrial_robot_client/src/joint_trajectory_action.cpp
@@ -45,8 +45,7 @@ const double JointTrajectoryAction::DEFAULT_GOAL_THRESHOLD_ = 0.01;
 JointTrajectoryAction::JointTrajectoryAction() :
     action_server_(node_, "joint_trajectory_action", boost::bind(&JointTrajectoryAction::goalCB, this, _1),
                    boost::bind(&JointTrajectoryAction::cancelCB, this, _1), false), has_active_goal_(false),
-                   controller_alive_(false), has_moved_once_(false), name_("joint_trajectory_action"),
-                   ignore_motion_server_error_(false), consider_status_unknowns_ok_(false)
+                   controller_alive_(false), has_moved_once_(false), name_("joint_trajectory_action")
 {
   ros::NodeHandle pn("~");
 

--- a/industrial_robot_client/src/joint_trajectory_action.cpp
+++ b/industrial_robot_client/src/joint_trajectory_action.cpp
@@ -52,7 +52,6 @@ JointTrajectoryAction::JointTrajectoryAction() :
   pn.param("constraints/goal_threshold", goal_threshold_, DEFAULT_GOAL_THRESHOLD_);
 
   // Two parameters for bw-compatibility with the 'old' behaviour.
-  // Setting these by default to TRUE, to maintain the previous behaviour
   pn.param("ignore_motion_server_error", ignore_motion_server_error_, ignore_motion_server_error_);
   pn.param("consider_status_unknowns_ok", consider_status_unknowns_ok_, consider_status_unknowns_ok_);
   std::string log_msg = std::string("Ignoring motion server errors: ") + (ignore_motion_server_error_ ? "true" : "false");
@@ -60,7 +59,7 @@ JointTrajectoryAction::JointTrajectoryAction() :
     ROS_WARN_STREAM_NAMED(name_, log_msg);
   else
     ROS_INFO_STREAM_NAMED(name_, log_msg);
-  log_msg = std::string("Treating RobotStatus fields with UNKNOWNs as ok: ") + (consider_status_unknowns_ok_ ? "true" : "false");
+  log_msg = std::string("Treating RobotStatus fields with UNKNOWNs as OK: ") + (consider_status_unknowns_ok_ ? "true" : "false");
   if (consider_status_unknowns_ok_)
     ROS_WARN_STREAM_NAMED(name_, log_msg);
   else

--- a/industrial_robot_client/src/joint_trajectory_action.cpp
+++ b/industrial_robot_client/src/joint_trajectory_action.cpp
@@ -142,7 +142,7 @@ std::string describeRobotStatusMsg(industrial_msgs::RobotStatusConstPtr& msg, bo
   if (utils::tri_state::isOn(msg->e_stopped, unknown_is_on))
   {
     ss.clear();
-    ss << "controller reported e-stop";
+    ss << "robot controller reported e-stop";
   }
   // some (generic ?) other error
   else if (msg->error_code != 0 || utils::tri_state::isOn(msg->in_error, unknown_is_on))

--- a/industrial_robot_client/src/joint_trajectory_action.cpp
+++ b/industrial_robot_client/src/joint_trajectory_action.cpp
@@ -380,7 +380,7 @@ void JointTrajectoryAction::controllerStateCB(const control_msgs::FollowJointTra
 
   if (!has_moved_once_ && (ros::Time::now() < time_to_check_))
   {
-    ROS_INFO_NAMED(name_, "Waiting to check for goal completion until halfway through trajectory");
+    ROS_DEBUG_NAMED(name_, "Waiting to check for goal completion until halfway through trajectory");
     return;
   }
 

--- a/industrial_robot_client/src/joint_trajectory_action.cpp
+++ b/industrial_robot_client/src/joint_trajectory_action.cpp
@@ -167,7 +167,7 @@ std::string describeRobotStatusMsg(industrial_msgs::RobotStatusConstPtr& msg, bo
   else if (utils::tri_state::isOff(msg->motion_possible, unknown_is_on))
   {
     ss.clear();
-    ss << "controller reported motion not possible (no further information)";
+    ss << "robot controller reported motion not possible (no further information)";
   }
 
   return ss.str();

--- a/industrial_robot_client/src/joint_trajectory_action.cpp
+++ b/industrial_robot_client/src/joint_trajectory_action.cpp
@@ -52,6 +52,21 @@ JointTrajectoryAction::JointTrajectoryAction() :
 
   pn.param("constraints/goal_threshold", goal_threshold_, DEFAULT_GOAL_THRESHOLD_);
 
+  // Two parameters for bw-compatibility with the 'old' behaviour.
+  // Setting these by default to TRUE, to maintain the previous behaviour
+  pn.param("ignore_motion_server_error", ignore_motion_server_error_, true);
+  pn.param("consider_status_unknowns_ok", consider_status_unknowns_ok_, true);
+  std::string log_msg = std::string("Ignoring motion server errors: ") + (ignore_motion_server_error_ ? "true" : "false");
+  if (ignore_motion_server_error_)
+    ROS_WARN_STREAM_NAMED(name_, log_msg);
+  else
+    ROS_INFO_STREAM_NAMED(name_, log_msg);
+  log_msg = std::string("Treating RobotStatus fields with UNKNOWNs as ok: ") + (consider_status_unknowns_ok_ ? "true" : "false");
+  if (consider_status_unknowns_ok_)
+    ROS_WARN_STREAM_NAMED(name_, log_msg);
+  else
+    ROS_INFO_STREAM_NAMED(name_, log_msg);
+
   if (!industrial_utils::param::getJointNames("controller_joint_names", "robot_description", joint_names_))
     ROS_ERROR_NAMED(name_, "Failed to initialize joint_names.");
 

--- a/industrial_robot_client/src/joint_trajectory_action.cpp
+++ b/industrial_robot_client/src/joint_trajectory_action.cpp
@@ -272,9 +272,7 @@ void JointTrajectoryAction::cancelCB(JointTractoryActionServer::GoalHandle gh)
   if (active_goal_ == gh)
   {
     // Stops the controller.
-    trajectory_msgs::JointTrajectory empty;
-    empty.joint_names = joint_names_;
-    pub_trajectory_command_.publish(empty);
+    stopRelay();
 
     // Marks the current goal as canceled.
     active_goal_.setCanceled();
@@ -323,9 +321,7 @@ void JointTrajectoryAction::controllerStateCB(const control_msgs::FollowJointTra
       + describe_robot_status_msg(last_robot_status_, consider_status_unknowns_ok_) };
 
     // Stop the relay
-    trajectory_msgs::JointTrajectory empty;
-    empty.joint_names = joint_names_;
-    pub_trajectory_command_.publish(empty);
+    stopRelay();
 
     // return abort to action client
     control_msgs::FollowJointTrajectoryResult result;
@@ -384,12 +380,16 @@ void JointTrajectoryAction::controllerStateCB(const control_msgs::FollowJointTra
   }
 }
 
-void JointTrajectoryAction::abortGoal()
+void JointTrajectoryAction::stopRelay()
 {
   // Stops the controller.
   trajectory_msgs::JointTrajectory empty;
   pub_trajectory_command_.publish(empty);
+}
 
+void JointTrajectoryAction::abortGoal()
+{
+  stopRelay();
   // Marks the current goal as aborted.
   active_goal_.setAborted();
   has_active_goal_ = false;

--- a/industrial_robot_client/src/joint_trajectory_action.cpp
+++ b/industrial_robot_client/src/joint_trajectory_action.cpp
@@ -130,10 +130,10 @@ bool isMotionServerOK(industrial_msgs::RobotStatusConstPtr& msg, bool unknown_is
   //  - in_error == false
   //  - e_stopped == false
   //  - no error code
-  return utils::isOn(msg->motion_possible, unknown_is_ok)
+  return utils::tri_state::isOn(msg->motion_possible, unknown_is_ok)
     && msg->error_code == 0
-    && utils::isOff(msg->in_error, unknown_is_ok)
-    && utils::isOff(msg->e_stopped, unknown_is_ok);
+    && utils::tri_state::isOff(msg->in_error, unknown_is_ok)
+    && utils::tri_state::isOff(msg->e_stopped, unknown_is_ok);
 }
 
 std::string describeRobotStatusMsg(industrial_msgs::RobotStatusConstPtr& msg, bool unknown_is_on = false)
@@ -141,13 +141,13 @@ std::string describeRobotStatusMsg(industrial_msgs::RobotStatusConstPtr& msg, bo
   std::stringstream ss;
 
   // mention e-stop specifically
-  if (utils::isOn(msg->e_stopped, unknown_is_on))
+  if (utils::tri_state::isOn(msg->e_stopped, unknown_is_on))
   {
     ss.clear();
     ss << "controller reported e-stop";
   }
   // some (generic ?) other error
-  else if (msg->error_code != 0 || utils::isOn(msg->in_error, unknown_is_on))
+  else if (msg->error_code != 0 || utils::tri_state::isOn(msg->in_error, unknown_is_on))
   {
     ss.clear();
     ss << "controller reported (active) error";
@@ -166,7 +166,7 @@ std::string describeRobotStatusMsg(industrial_msgs::RobotStatusConstPtr& msg, bo
   // the state server decides motion_possible == false. So we first
   // check the specific problems above, then fall back to this generic
   // "it doesn't work, don't know why" statement
-  else if (utils::isOff(msg->motion_possible, unknown_is_on))
+  else if (utils::tri_state::isOff(msg->motion_possible, unknown_is_on))
   {
     ss.clear();
     ss << "controller reported motion not possible (no further information)";
@@ -352,13 +352,13 @@ void JointTrajectoryAction::controllerStateCB(const control_msgs::FollowJointTra
       // be moving.  The current robot driver calls a motion stop if it receives
       // a new trajectory while it is still moving.  If the driver is not publishing
       // the motion state (i.e. old driver), this will still work, but it warns you.
-      if (utils::isOff(last_robot_status_->in_motion, /*unknown_is_off=*/false))
+      if (utils::tri_state::isOff(last_robot_status_->in_motion, /*unknown_is_off=*/false))
       {
         ROS_INFO_NAMED("joint_trajectory_action.controllerStateCB", "Inside goal constraints - stopped moving - return success for action");
         active_goal_.setSucceeded();
         has_active_goal_ = false;
       }
-      else if (utils::isUnknown(last_robot_status_->in_motion))
+      else if (utils::tri_state::isUnknown(last_robot_status_->in_motion))
       {
         ROS_INFO_NAMED(name_, "Inside goal constraints, return success for action");
         ROS_WARN_NAMED(name_, "Robot status in motion unknown, the robot driver node and controller code should be updated");

--- a/industrial_robot_client/src/joint_trajectory_action.cpp
+++ b/industrial_robot_client/src/joint_trajectory_action.cpp
@@ -55,7 +55,7 @@ JointTrajectoryAction::JointTrajectoryAction() :
   // Two parameters for bw-compatibility with the 'old' behaviour.
   // Setting these by default to TRUE, to maintain the previous behaviour
   pn.param("ignore_motion_server_error", ignore_motion_server_error_, ignore_motion_server_error_);
-  pn.param("consider_status_unknowns_ok", consider_status_unknowns_ok_, true);
+  pn.param("consider_status_unknowns_ok", consider_status_unknowns_ok_, consider_status_unknowns_ok_);
   std::string log_msg = std::string("Ignoring motion server errors: ") + (ignore_motion_server_error_ ? "true" : "false");
   if (ignore_motion_server_error_)
     ROS_WARN_STREAM_NAMED(name_, log_msg);

--- a/industrial_robot_client/src/joint_trajectory_action.cpp
+++ b/industrial_robot_client/src/joint_trajectory_action.cpp
@@ -201,6 +201,7 @@ void JointTrajectoryAction::goalCB(JointTractoryActionServer::GoalHandle gh)
     // the goal is actually probably OK, but we have to choose one of the existing
     // constants, and this one comes closest
     rslt.error_code = control_msgs::FollowJointTrajectoryResult::INVALID_GOAL;
+    rslt.error_string = reject_msg;
     gh.setRejected(rslt, reject_msg);
 
     // no point in continuing: already rejected

--- a/industrial_robot_client/src/joint_trajectory_action.cpp
+++ b/industrial_robot_client/src/joint_trajectory_action.cpp
@@ -396,13 +396,13 @@ void JointTrajectoryAction::controllerStateCB(const control_msgs::FollowJointTra
       // be moving.  The current robot driver calls a motion stop if it receives
       // a new trajectory while it is still moving.  If the driver is not publishing
       // the motion state (i.e. old driver), this will still work, but it warns you.
-      if (last_robot_status_->in_motion.val == industrial_msgs::TriState::FALSE)
+      if (is_off(last_robot_status_->in_motion, /*unknown_is_off=*/false))
       {
         ROS_INFO_NAMED("joint_trajectory_action.controllerStateCB", "Inside goal constraints - stopped moving-  return success for action");
         active_goal_.setSucceeded();
         has_active_goal_ = false;
       }
-      else if (last_robot_status_->in_motion.val == industrial_msgs::TriState::UNKNOWN)
+      else if (is_unknown(last_robot_status_->in_motion))
       {
         ROS_INFO_NAMED(name_, "Inside goal constraints, return success for action");
         ROS_WARN_NAMED(name_, "Robot status in motion unknown, the robot driver node and controller code should be updated");

--- a/industrial_robot_client/src/joint_trajectory_action.cpp
+++ b/industrial_robot_client/src/joint_trajectory_action.cpp
@@ -148,7 +148,7 @@ std::string describeRobotStatusMsg(industrial_msgs::RobotStatusConstPtr& msg, bo
   else if (msg->error_code != 0 || utils::tri_state::isOn(msg->in_error, unknown_is_on))
   {
     ss.clear();
-    ss << "controller reported (active) error";
+    ss << "robot controller reported (active) error";
 
     // it could be state server does not report specific error codes
     if (msg->error_code != 0)


### PR DESCRIPTION
Sort-of, as it's actually a bit more than what was included in #83.

The proposed changes make the `joint_trajectory_action` aware of the state of the (OEM) motion server program (as far as it publishes that in the form of `RobotStatus` messages). In two cases is this information taken into account:

 1. while accepting new goals
 2. while executing already accepted goals

In both cases, the following is monitored / checked:

 1. is an e-stop active?
 2. is there some other error active?
 3. does the motion server report `motion_possible` is `true`?

If any of these are not as expected, the goal is rejected, or, if a goal is currently being processed (ie: motion is execution), the goal is aborted and trajectory execution cancelled (as that should now work, with #260 merged (which still requires a cooperating driver of course)).

In all cases, the action result would be `INVALID_GOAL`, as unfortunately the `FollowJointTrajectory` action message does not define any really more suitable error codes.

Also in all cases: the reason for aborting or rejecting a goal is described in a human readable message.

When rejecting goals:

```
[ERROR] [...]: Rejecting goal: controller reported motion not possible (no further information)
[ERROR] [...]: Rejecting goal: controller reported (active) error (OEM code: 11003)
[ERROR] [...]: Rejecting goal: controller reported e-stop
```

When aborting goals:

```
[ERROR] [...]: Aborting goal: controller reported motion not possible (no further information)
[ERROR] [...]: Aborting goal: controller reported (active) error (OEM code: 11003)
[ERROR] [...]: Aborting goal: controller reported e-stop
```

(this is output from `fanuc_driver`: `11003` is *Deadman switch released*, which will indeed prevent any motion in manual mode)

While this is certainly not perfect (it doesn't address #265 nor #118), together with #263 and #260 and an (OEM) relay which behaves according to the spec, the UX of `industrial_robot_client` is improved quite a bit.

Lastly: as previous versions of the JTA did not check anything, misbehaving drivers would still be able to execute motions, even if they didn't properly populate all fields of the `RobotStatus` messages. In order to still allow usage of such systems, two new parameters were added which can be used to revert the JTA back to its previous behaviour (ie: don't check anything, always forward goals to drivers).

In the current implementation, the default is to disable these new checks. Something to discuss is whether we should make the default to *enable* the new checks, and users with misbehaving drivers should instead be required to explicitly enable the bw-compatible behaviour.
