### PR TITLE
Add bw-compatibility to simple_message ifdefs

### DIFF
--- a/simple_message/include/simple_message/log_wrapper.h
+++ b/simple_message/include/simple_message/log_wrapper.h
@@ -32,7 +32,8 @@
 #ifndef LOG_WRAPPER_H_
 #define LOG_WRAPPER_H_
 
-#ifdef SIMPLE_MESSAGE_USE_ROS
+// remove ROS after Melodic (bw compat for #262)
+#if defined(SIMPLE_MESSAGE_USE_ROS) || defined(ROS)
 #include "ros/ros.h"
 #endif
 
@@ -55,7 +56,8 @@ namespace log_wrapper
     
 
 // Define ROS if this library will execute under ROS
-#ifdef SIMPLE_MESSAGE_USE_ROS
+// remove ROS after Melodic (bw compat for #262)
+#if defined(SIMPLE_MESSAGE_USE_ROS) || defined(ROS)
 
 // The LOG_COMM redirects to debug in ROS because ROS has
 // debug filtering tools that allow the communications messages

--- a/simple_message/include/simple_message/robot_status.h
+++ b/simple_message/include/simple_message/robot_status.h
@@ -60,7 +60,8 @@ enum RobotMode
   MANUAL = 1, AUTO = 2,
 };
 
-#ifdef SIMPLE_MESSAGE_USE_ROS
+// remove ROS after Melodic (bw compat for #262)
+#if defined(SIMPLE_MESSAGE_USE_ROS) || defined(ROS)
 int toROSMsgEnum(RobotModes::RobotMode mode);
 #endif
 
@@ -85,7 +86,8 @@ enum TriState
   TS_FALSE = 0,   TS_OFF = 0,  TS_DISABLED = 0,  TS_LOW = 0
 };
 
-#ifdef SIMPLE_MESSAGE_USE_ROS
+// remove ROS after Melodic (bw compat for #262)
+#if defined(SIMPLE_MESSAGE_USE_ROS) || defined(ROS)
 int toROSMsgEnum(TriStates::TriState state);
 #endif
 

--- a/simple_message/include/simple_message/socket/simple_socket.h
+++ b/simple_message/include/simple_message/socket/simple_socket.h
@@ -42,7 +42,8 @@
 #include "smpl_msg_connection.h"
 #endif
 
-#ifdef SIMPLE_MESSAGE_LINUX
+// remove LINUXSOCKETS after Melodic (bw compat for #262)
+#if defined(SIMPLE_MESSAGE_LINUX) || defined(LINUXSOCKETS)
 
 #ifndef _WIN32
 #include "sys/socket.h"

--- a/simple_message/include/simple_message/socket/tcp_socket.h
+++ b/simple_message/include/simple_message/socket/tcp_socket.h
@@ -40,7 +40,8 @@
 #include "shared_types.h"
 #endif
 
-#ifdef SIMPLE_MESSAGE_LINUX
+// remove LINUXSOCKETS after Melodic (bw compat for #262)
+#if defined(SIMPLE_MESSAGE_LINUX) || defined(LINUXSOCKETS)
 #ifndef WIN32
 #include "sys/socket.h"
 #include "netdb.h"

--- a/simple_message/include/simple_message/socket/udp_socket.h
+++ b/simple_message/include/simple_message/socket/udp_socket.h
@@ -42,7 +42,8 @@
 #include "smpl_msg_connection.h"
 #endif
 
-#ifdef SIMPLE_MESSAGE_LINUX
+// remove LINUXSOCKETS after Melodic (bw compat for #262)
+#if defined(SIMPLE_MESSAGE_LINUX) || defined(LINUXSOCKETS)
 #ifndef WIN32
 #include "sys/socket.h"
 #include "netdb.h"

--- a/simple_message/src/message_manager.cpp
+++ b/simple_message/src/message_manager.cpp
@@ -38,7 +38,8 @@
 #include "simple_message.h"
 #endif
 
-#ifdef SIMPLE_MESSAGE_USE_ROS
+// remove ROS after Melodic (bw compat for #262)
+#if defined(SIMPLE_MESSAGE_USE_ROS) || defined(ROS)
 #include "ros/ros.h"
 #else
 #include "unistd.h"
@@ -187,7 +188,8 @@ void mySleep(int sec)
 void MessageManager::spin()
 {
   LOG_INFO("Entering message manager spin loop");
-#ifdef SIMPLE_MESSAGE_USE_ROS
+// remove ROS after Melodic (bw compat for #262)
+#if defined(SIMPLE_MESSAGE_USE_ROS) || defined(ROS)
   while (ros::ok())
 #else
   while (true)

--- a/simple_message/src/robot_status.cpp
+++ b/simple_message/src/robot_status.cpp
@@ -38,7 +38,8 @@
 #include "log_wrapper.h"
 #endif
 
-#ifdef SIMPLE_MESSAGE_USE_ROS
+// remove ROS after Melodic (bw compat for #262)
+#if defined(SIMPLE_MESSAGE_USE_ROS) || defined(ROS)
 // Files below used to translate between ROS messages enums and
 // enums defined in this file
 #include "industrial_msgs/RobotMode.h"
@@ -55,7 +56,8 @@ namespace robot_status
 namespace RobotModes
 {
 
-#ifdef SIMPLE_MESSAGE_USE_ROS
+// remove ROS after Melodic (bw compat for #262)
+#if defined(SIMPLE_MESSAGE_USE_ROS) || defined(ROS)
 
 int toROSMsgEnum(RobotModes::RobotMode mode)
 {
@@ -83,7 +85,8 @@ int toROSMsgEnum(RobotModes::RobotMode mode)
 namespace TriStates
 {
 
-#ifdef SIMPLE_MESSAGE_USE_ROS
+// remove ROS after Melodic (bw compat for #262)
+#if defined(SIMPLE_MESSAGE_USE_ROS) || defined(ROS)
 
 int toROSMsgEnum(TriStates::TriState state)
 {


### PR DESCRIPTION
For now (ie: in `melodic` and `melodic-devel`), accept the old `#define`s `ROS` and `LINUXSOCKETS` in addition to the newer ones (ie: the namespaced ones).

Should fix #274 and fix builds which haven't been updated to use the new `simple_message_DEFINITIONS`.

This was already suggested actually by @jdlangs in #190, but I removed it, hoping to get away with it in Melodic.

Unfortunately that didn't work, so here we are.
