### PR TITLE
Fix out of bound access of trajectory points

### DIFF
--- a/industrial_trajectory_filters/src/uniform_sample_filter.cpp
+++ b/industrial_trajectory_filters/src/uniform_sample_filter.cpp
@@ -77,6 +77,12 @@ template<typename T>
 
     trajectory_out = trajectory_in;
 
+    if(size_in <= 1)
+    {
+      ROS_WARN("A minimal trajectory of 2 points is required to apply a uniform sampling filter");
+      return false;
+    }
+
     // Clear out the trajectory points
     trajectory_out.request.trajectory.points.clear();
 


### PR DESCRIPTION
The filter needs at least 2 samples to interpolate the input trajectory with the current algorithm. Skip the filter if the required points is not met.