### PR TITLE
[ROS-O] No explicit requests for c++11

### DIFF
--- a/industrial_robot_client/CMakeLists.txt
+++ b/industrial_robot_client/CMakeLists.txt
@@ -2,9 +2,6 @@ cmake_minimum_required(VERSION 3.0.2)
 
 project(industrial_robot_client)
 
-set(CMAKE_CXX_STANDARD 11)
-set(CMAKE_CXX_STANDARD_REQUIRED ON)
-
 find_package(catkin REQUIRED COMPONENTS actionlib actionlib_msgs
   control_msgs industrial_msgs industrial_utils roscpp sensor_msgs
   simple_message std_msgs trajectory_msgs urdf)

--- a/industrial_trajectory_filters/CMakeLists.txt
+++ b/industrial_trajectory_filters/CMakeLists.txt
@@ -2,8 +2,6 @@ cmake_minimum_required(VERSION 3.0.2)
 
 project(industrial_trajectory_filters)
 
-add_compile_options(-std=c++11)
-
 find_package(catkin REQUIRED COMPONENTS
   class_loader
   moveit_core

--- a/simple_message/CMakeLists.txt
+++ b/simple_message/CMakeLists.txt
@@ -2,9 +2,6 @@ cmake_minimum_required(VERSION 3.0.2)
 
 project(simple_message)
 
-set(CMAKE_CXX_STANDARD 11)
-set(CMAKE_CXX_STANDARD_REQUIRED ON)
-
 find_package(catkin REQUIRED COMPONENTS industrial_msgs roscpp)
 
 # The simple message make file builds three libraries: simple_message,


### PR DESCRIPTION
C++11 has been the default for compilers targeted in this branch.

gtest requires c++14 since v1.13 (Jan 2023) and building the tests on newer systems fails.

If this is not endorsed by the authors, it's also possible to check for externally provided values for `CXX_STANDARD` before setting it, but it's much more convenient to simply drop it and keep the codebase compiling without special triggers on modern systems.
